### PR TITLE
Update WebApiOutputCacheAttribute.cs

### DIFF
--- a/WebApiOutputCacheAttribute.cs
+++ b/WebApiOutputCacheAttribute.cs
@@ -79,6 +79,7 @@ namespace WebApi.OutputCache
                             ac.Response.Content = new StringContent(val);
 
                             ac.Response.Content.Headers.ContentType = contenttype;
+                            ac.Response.Headers.CacheControl = this.setClientCache();
                             return;
                         }
                     }


### PR DESCRIPTION
I think there is a bug.  You need to fire setClientCache() in OnActionExecuting too.

Reproduction steps:

Create page that makes a JS call to a WepAPI controller with the caching set.

The response will have the appropriate caching headers.

Subsequent calls will correctly come from cache.

Force a refresh by pressing F5, the response will now come back with Cache-Control:no-cache.
