### PR TITLE
Update WebApiOutputCacheAttribute.cs

### DIFF
--- a/WebApiOutputCacheAttribute.cs
+++ b/WebApiOutputCacheAttribute.cs
@@ -63,8 +63,13 @@ namespace WebApi.OutputCache
             {
                 if (_isCachingTimeValid(_timespan, ac, _anonymousOnly))
                 {
-                    _cachekey = string.Join(":", new string[] { ac.Request.RequestUri.PathAndQuery, ac.Request.Headers.Accept.FirstOrDefault().ToString() });
+                    MediaTypeWithQualityHeaderValue mediaTypeWithQualityHeaderValue = ac.Request.Headers.Accept.FirstOrDefault();
+                    string acceptHeader = (mediaTypeWithQualityHeaderValue == null)
+                                              ? "Default"
+                                              : mediaTypeWithQualityHeaderValue.ToString();
 
+                    _cachekey = string.Join(":", new string[] { ac.Request.RequestUri.PathAndQuery, acceptHeader });
+                    
                     if (WebApiCache.Contains(_cachekey))
                     {
                         var val = WebApiCache.Get(_cachekey) as string;


### PR DESCRIPTION
I have found another bug.  An exception occurs when no Accept headers are passed in with the request.

This causes a NullReferenceException.

I have changed it to use "Default" if no Accept header has been passed in.  

You may well have a better way of achieving this, so please refactor as you see fit.
