### PR TITLE
Reenable ClientTimeSpan zero and ServerTimeSpan zero

### DIFF
--- a/WebAPI.OutputCache.Demo/WebAPI.OutputCache.Demo.csproj
+++ b/WebAPI.OutputCache.Demo/WebAPI.OutputCache.Demo.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WebAPI.OutputCache.Demo</RootNamespace>
     <AssemblyName>WebAPI.OutputCache.Demo</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/WebAPI.OutputCache.Tests/ClientSideTests.cs
+++ b/WebAPI.OutputCache.Tests/ClientSideTests.cs
@@ -41,6 +41,25 @@ namespace WebAPI.OutputCache.Tests
         }
 
         [Test]
+        public void no_cachecontrol_when_clienttimeout_is_zero()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_c0_s100").Result;
+
+            Assert.IsNull(result.Headers.CacheControl);
+        }
+
+        [Test]
+        public void maxage_mustrevalidate_headers_correct_with_clienttimeout_zero_with_must_revalidate()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_c0_s100_mustR").Result;
+
+            Assert.IsTrue(result.Headers.CacheControl.MustRevalidate);
+            Assert.AreEqual(TimeSpan.Zero, result.Headers.CacheControl.MaxAge);
+        }
+
+        [Test]
         public void maxage_mustrevalidate_true_headers_correct()
         {
             var client = new HttpClient(_server);
@@ -54,9 +73,10 @@ namespace WebAPI.OutputCache.Tests
         public void maxage_mustrevalidate_headers_correct_with_cacheuntil()
         {
             var client = new HttpClient(_server);
-            var result = client.GetAsync(_url + "Get_until25012013_1700").Result;
-
-            Assert.IsTrue(Math.Round(new SpecificTime(2013, 01, 25, 17, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds - ((TimeSpan)result.Headers.CacheControl.MaxAge).TotalSeconds) == 0);
+            var result = client.GetAsync(_url + "Get_until25012015_1700").Result;
+            var clientTimeSpanSeconds = new SpecificTime(2015, 01, 25, 17, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds;
+            var resultCacheControlSeconds = ((TimeSpan) result.Headers.CacheControl.MaxAge).TotalSeconds;
+            Assert.IsTrue(Math.Round(clientTimeSpanSeconds - resultCacheControlSeconds) == 0);
             Assert.IsFalse(result.Headers.CacheControl.MustRevalidate);
         }
 

--- a/WebAPI.OutputCache.Tests/ServerSideTests.cs
+++ b/WebAPI.OutputCache.Tests/ServerSideTests.cs
@@ -48,8 +48,21 @@ namespace WebAPI.OutputCache.Tests
             var result = client.GetAsync(_url + "Get_c100_s100").Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_c100_s100:application/json")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "sample-get_c100_s100")), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "sample-get_c100_s100")), Times.Once());
+        }
+
+        [Test]
+        public void set_cache_to_predefined_value_c100_s0()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_c100_s0").Result;
+            
+            // NOTE: Should we expect the _cache to not be called at all if the ServerTimeSpan is 0?
+            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_c100_s0:application/json")), Times.Once());
+            // NOTE: Server timespan is 0, so there should not have been any Add at all.
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s0"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), null), Times.Never());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s0:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(1)), It.Is<string>(x => x == "sample-get_c100_s0")), Times.Never());
         }
 
         [Test]
@@ -61,8 +74,8 @@ namespace WebAPI.OutputCache.Tests
             var result = client.SendAsync(req).Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_c100_s100:text/xml")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100:text/xml"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "sample-get_c100_s100")), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100:text/xml"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "sample-get_c100_s100")), Times.Once());
         }
 
         [Test]
@@ -75,8 +88,8 @@ namespace WebAPI.OutputCache.Tests
             var result = client.SendAsync(req).Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_c100_s100:text/xml")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100:text/xml"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "sample-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_c100_s100:text/xml"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "sample-get_c100_s100")), Times.Exactly(1));
         }
 
         [Test]
@@ -86,8 +99,8 @@ namespace WebAPI.OutputCache.Tests
             var result = client.GetAsync(_url + "Get_s50_exclude_false?id=1").Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_s50_exclude_false-id=1:application/json")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_false"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_false-id=1:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_false")), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_false"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_false-id=1:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_false")), Times.Once());
         }
 
         [Test]
@@ -97,8 +110,8 @@ namespace WebAPI.OutputCache.Tests
             var result = client.GetAsync(_url + "Get_s50_exclude_true?id=1").Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_s50_exclude_true:application/json")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_true"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_true:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_true")), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_true"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_true:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_true")), Times.Once());
         }
 
         [Test]
@@ -108,8 +121,8 @@ namespace WebAPI.OutputCache.Tests
             var result = client.GetAsync(_url + "Get_s50_exclude_fakecallback?id=1&callback=abc").Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1:application/json")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback")), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback")), Times.Once());
         }
 
         [Test]
@@ -119,8 +132,8 @@ namespace WebAPI.OutputCache.Tests
             var result = client.GetAsync(_url + "Get_s50_exclude_fakecallback?callback=abc&id=1").Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1:application/json")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback")), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback")), Times.Once());
         }
 
         [Test]
@@ -130,8 +143,8 @@ namespace WebAPI.OutputCache.Tests
             var result = client.GetAsync(_url + "Get_s50_exclude_fakecallback?de=xxx&callback=abc&id=1").Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1&de=xxx:application/json")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1&de=xxx:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback")), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback-id=1&de=xxx:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback")), Times.Once());
         }
 
         [Test]
@@ -141,8 +154,8 @@ namespace WebAPI.OutputCache.Tests
             var result = client.GetAsync(_url + "Get_s50_exclude_fakecallback?callback=abc").Result;
 
             _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback:application/json")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), null), Times.Once());
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback")), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback:application/json"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(50)), It.Is<string>(x => x == "sample-get_s50_exclude_fakecallback")), Times.Once());
         }
 
         [Test]

--- a/WebAPI.OutputCache.Tests/TestControllers/SampleController.cs
+++ b/WebAPI.OutputCache.Tests/TestControllers/SampleController.cs
@@ -11,6 +11,24 @@ namespace WebAPI.OutputCache.Tests.TestControllers
             return "test";
         }
 
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 0)]
+        public string Get_c100_s0()
+        {
+            return "test";
+        }
+
+        [CacheOutput(ClientTimeSpan = 0, ServerTimeSpan = 100)]
+        public string Get_c0_s100()
+        {
+            return "test";
+        }
+
+        [CacheOutput(ClientTimeSpan = 0, ServerTimeSpan = 100, MustRevalidate = true)]
+        public string Get_c0_s100_mustR()
+        {
+            return "test";
+        }
+
         [CacheOutput(ClientTimeSpan = 50, MustRevalidate = true)]
         public string Get_c50_mustR()
         {
@@ -35,8 +53,8 @@ namespace WebAPI.OutputCache.Tests.TestControllers
             return "test" + id;
         }
 
-        [CacheOutputUntil(2013,01,25,17,00)]
-        public string Get_until25012013_1700()
+        [CacheOutputUntil(2015,01,25,17,00)]
+        public string Get_until25012015_1700()
         {
             return "test";
         }

--- a/WebAPI.OutputCache.Tests/WebAPI.OutputCache.Tests.csproj
+++ b/WebAPI.OutputCache.Tests/WebAPI.OutputCache.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WebAPI.OutputCache.Tests</RootNamespace>
     <AssemblyName>WebAPI.OutputCache.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -68,18 +68,34 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClientSideTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="ConfigurationTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="ConnegTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="InlineInvalidateTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="InvalidateTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="MemoryCacheDefaultTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="ServerSideTests.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="TestControllers\AutoInvalidateController.cs" />
-    <Compile Include="ConnegTests.cs" />
-    <Compile Include="ConfigurationTests.cs" />
     <Compile Include="TestControllers\AutoInvalidateWithTypeController.cs" />
     <Compile Include="TestControllers\InlineInvalidateController.cs" />
-    <Compile Include="InlineInvalidateTests.cs" />
-    <Compile Include="InvalidateTests.cs" />
-    <Compile Include="MemoryCacheDefaultTests.cs" />
-    <Compile Include="ServerSideTests.cs" />
-    <Compile Include="TestControllers\SampleController.cs" />
-    <Compile Include="ClientSideTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestControllers\SampleController.cs">
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\WebAPI.OutputCache\WebAPI.OutputCache.csproj">

--- a/WebAPI.OutputCache.sln
+++ b/WebAPI.OutputCache.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI.OutputCache", "WebAPI.OutputCache\WebAPI.OutputCache.csproj", "{4F32DC89-081B-4264-92F8-F3371A088EB4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAPI.OutputCache.Tests", "WebAPI.OutputCache.Tests\WebAPI.OutputCache.Tests.csproj", "{C5DFB349-FA13-41A1-9F11-332E88664DF7}"

--- a/WebAPI.OutputCache/CacheOutputAttribute.cs
+++ b/WebAPI.OutputCache/CacheOutputAttribute.cs
@@ -111,41 +111,46 @@ namespace WebAPI.OutputCache
             if (!_isCachingAllowed(actionExecutedContext.ActionContext, AnonymousOnly)) return;
 
             var cacheTime = CacheTimeQuery.Execute(DateTime.Now);
-            var cachekey = MakeCachekey(actionExecutedContext.ActionContext, _responseMediaType, ExcludeQueryStringFromCacheKey);
-
-            if (!string.IsNullOrWhiteSpace(cachekey) && !(WebApiCache.Contains(cachekey)))
+            if (cacheTime.AbsoluteExpiration > DateTime.Now)
             {
-                SetEtag(actionExecutedContext.Response, Guid.NewGuid().ToString());
+                var cachekey = MakeCachekey(actionExecutedContext.ActionContext, _responseMediaType, ExcludeQueryStringFromCacheKey);
 
-                actionExecutedContext.Response.Content.ReadAsStringAsync().ContinueWith(t =>
-                    {
-                        var baseKey = actionExecutedContext.Request.GetConfiguration().CacheOutputConfiguration().MakeBaseCachekey(actionExecutedContext.ActionContext.ControllerContext.ControllerDescriptor.ControllerName, actionExecutedContext.ActionContext.ActionDescriptor.ActionName);
-                        WebApiCache.Add(baseKey, string.Empty, cacheTime.AbsoluteExpiration);
-                        WebApiCache.Add(cachekey, t.Result, cacheTime.AbsoluteExpiration, baseKey);
-                        
-                        WebApiCache.Add(cachekey + Constants.ContentTypeKey,
-                                        actionExecutedContext.Response.Content.Headers.ContentType,
-                                        cacheTime.AbsoluteExpiration, baseKey);
+                if (!string.IsNullOrWhiteSpace(cachekey) && !(WebApiCache.Contains(cachekey)))
+                {
+                    SetEtag(actionExecutedContext.Response, Guid.NewGuid().ToString());
 
-                        WebApiCache.Add(cachekey + Constants.EtagKey,
-                                      actionExecutedContext.Response.Headers.ETag,
-                                      cacheTime.AbsoluteExpiration, baseKey); 
-                    });
+                    actionExecutedContext.Response.Content.ReadAsStringAsync().ContinueWith(t =>
+                        {
+                            var baseKey = actionExecutedContext.Request.GetConfiguration().CacheOutputConfiguration().MakeBaseCachekey(actionExecutedContext.ActionContext.ControllerContext.ControllerDescriptor.ControllerName, actionExecutedContext.ActionContext.ActionDescriptor.ActionName);
+                            WebApiCache.Add(baseKey, string.Empty, cacheTime.AbsoluteExpiration);
+                            WebApiCache.Add(cachekey, t.Result, cacheTime.AbsoluteExpiration, baseKey);
+
+                            WebApiCache.Add(cachekey + Constants.ContentTypeKey,
+                                            actionExecutedContext.Response.Content.Headers.ContentType,
+                                            cacheTime.AbsoluteExpiration, baseKey);
+
+                            WebApiCache.Add(cachekey + Constants.EtagKey,
+                                          actionExecutedContext.Response.Headers.ETag,
+                                          cacheTime.AbsoluteExpiration, baseKey);
+                        });
+                }
             }
-
             //if (!_isCachingAllowed(actionExecutedContext.ActionContext, AnonymousOnly)) return;
             ApplyCacheHeaders(actionExecutedContext.ActionContext.Response, cacheTime);
         }
 
         private void ApplyCacheHeaders(HttpResponseMessage response, CacheTime cacheTime)
         {
-            var cachecontrol = new CacheControlHeaderValue
+            if (cacheTime.ClientTimeSpan > TimeSpan.Zero || MustRevalidate)
             {
-                MaxAge = cacheTime.ClientTimeSpan,
-                MustRevalidate = MustRevalidate
-            };
+                var cachecontrol = new CacheControlHeaderValue
+                                       {
+                                           MaxAge = cacheTime.ClientTimeSpan,
+                                           MustRevalidate = MustRevalidate
+                                       };
 
-            response.Headers.CacheControl = cachecontrol;
+                response.Headers.CacheControl = cachecontrol;
+            }
         }
 
         private static void SetEtag(HttpResponseMessage message, string etag)

--- a/WebAPI.OutputCache/InvalidateCacheOutputAttribute.cs
+++ b/WebAPI.OutputCache/InvalidateCacheOutputAttribute.cs
@@ -11,6 +11,10 @@ namespace WebAPI.OutputCache
         private string _controller;
         private readonly string _methodName;
 
+        public InvalidateCacheOutputAttribute(string methodName) : this(methodName, null)
+        {
+        }
+
         public InvalidateCacheOutputAttribute(string methodName, Type type = null)
         {
             _controller = type != null ? type.Name.Replace("Controller", string.Empty) : null;

--- a/WebAPI.OutputCache/Time/CacheTime.cs
+++ b/WebAPI.OutputCache/Time/CacheTime.cs
@@ -4,9 +4,6 @@ namespace WebAPI.OutputCache.Time
 {
     public class CacheTime
     {
-        //// cache length in seconds
-        public TimeSpan ServerTimespan { get; set; }
-
         // client cache length in seconds
         public TimeSpan ClientTimeSpan { get; set; }
 

--- a/WebAPI.OutputCache/Time/ShortTime.cs
+++ b/WebAPI.OutputCache/Time/ShortTime.cs
@@ -9,13 +9,13 @@ namespace WebAPI.OutputCache.Time
 
         public ShortTime(int serverTimeInSeconds, int clientTimeInSeconds)
         {
-            if (serverTimeInSeconds < 1)
-                serverTimeInSeconds = 1;
+            if (serverTimeInSeconds < 0)
+                serverTimeInSeconds = 0;
 
             this.serverTimeInSeconds = serverTimeInSeconds;
 
-            if (clientTimeInSeconds < 1)
-                clientTimeInSeconds = 1;
+            if (clientTimeInSeconds < 0)
+                clientTimeInSeconds = 0;
 
             this.clientTimeInSeconds = clientTimeInSeconds;
         }
@@ -24,8 +24,7 @@ namespace WebAPI.OutputCache.Time
         {
             var cacheTime = new CacheTime
                 {
-                    AbsoluteExpiration = model.AddSeconds(clientTimeInSeconds),
-                    ServerTimespan = TimeSpan.FromSeconds(serverTimeInSeconds),
+                    AbsoluteExpiration = model.AddSeconds(serverTimeInSeconds),
                     ClientTimeSpan = TimeSpan.FromSeconds(clientTimeInSeconds)
                 };
 

--- a/WebAPI.OutputCache/Time/SpecificTime.cs
+++ b/WebAPI.OutputCache/Time/SpecificTime.cs
@@ -33,8 +33,7 @@ namespace WebAPI.OutputCache.Time
                                                       second),
                 };
 
-            cacheTime.ServerTimespan = cacheTime.AbsoluteExpiration.Subtract(model);
-            cacheTime.ClientTimeSpan = cacheTime.ServerTimespan;
+            cacheTime.ClientTimeSpan = cacheTime.AbsoluteExpiration.Subtract(model);
 
             return cacheTime;
         }

--- a/WebAPI.OutputCache/Time/ThisDay.cs
+++ b/WebAPI.OutputCache/Time/ThisDay.cs
@@ -30,8 +30,7 @@ namespace WebAPI.OutputCache.Time
             if (cacheTime.AbsoluteExpiration <= model)
                 cacheTime.AbsoluteExpiration = cacheTime.AbsoluteExpiration.AddDays(1);
 
-            cacheTime.ServerTimespan = cacheTime.AbsoluteExpiration.Subtract(model);
-            cacheTime.ClientTimeSpan = cacheTime.ServerTimespan;
+            cacheTime.ClientTimeSpan = cacheTime.AbsoluteExpiration.Subtract(model);
 
             return cacheTime;
         }

--- a/WebAPI.OutputCache/Time/ThisMonth.cs
+++ b/WebAPI.OutputCache/Time/ThisMonth.cs
@@ -32,8 +32,7 @@ namespace WebAPI.OutputCache.Time
             if (cacheTime.AbsoluteExpiration <= model)
                 cacheTime.AbsoluteExpiration = cacheTime.AbsoluteExpiration.AddMonths(1);
 
-            cacheTime.ServerTimespan = cacheTime.AbsoluteExpiration.Subtract(model);
-            cacheTime.ClientTimeSpan = cacheTime.ServerTimespan;
+            cacheTime.ClientTimeSpan = cacheTime.AbsoluteExpiration.Subtract(model);
 
             return cacheTime;
         }

--- a/WebAPI.OutputCache/Time/ThisYear.cs
+++ b/WebAPI.OutputCache/Time/ThisYear.cs
@@ -34,8 +34,7 @@ namespace WebAPI.OutputCache.Time
             if (cacheTime.AbsoluteExpiration <= model)
                 cacheTime.AbsoluteExpiration = cacheTime.AbsoluteExpiration.AddYears(1);
 
-            cacheTime.ServerTimespan = cacheTime.AbsoluteExpiration.Subtract(model);
-            cacheTime.ClientTimeSpan = cacheTime.ServerTimespan;
+            cacheTime.ClientTimeSpan = cacheTime.AbsoluteExpiration.Subtract(model);
 
             return cacheTime;
         }


### PR DESCRIPTION
When ServerTimeSpan is 0 then the response should not be stored in the webcache.
When ClientTimeSpan is 0 and MustRevalidate is false, then there should be no CacheControl header.
Removed ServerTimeSpan from CacheTime as it was not used anywhere.
Fixed Unit test that contained a date in the past.
Changed target framework to 4.0 for Demo and test project, so they open in VS2010.
Added attribute constructor overload instead of the default value, as that gave errors in VS2010.
