### PR TITLE
Fixing null ref exceptions in *InvalidateCacheOutput attributes

### DIFF
--- a/WebAPI.OutputCache/AutoInvalidateCacheOutputAttribute.cs
+++ b/WebAPI.OutputCache/AutoInvalidateCacheOutputAttribute.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
@@ -38,9 +36,9 @@ namespace WebAPI.OutputCache
                     WebApiCache.RemoveStartsWith(key);
                 }
             }
-        }        
+        }
 
-        private IEnumerable<string> FindAllGetMethods(Type controllerType, IEnumerable<HttpParameterDescriptor> httpParameterDescriptors)
+        private static IEnumerable<string> FindAllGetMethods(Type controllerType, IEnumerable<HttpParameterDescriptor> httpParameterDescriptors)
         {
             var actions = controllerType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
             var filteredActions = actions.Where(x =>
@@ -67,10 +65,10 @@ namespace WebAPI.OutputCache
 
             var projectedActions = filteredActions.Select(x =>
                 {
-                    var overridenNames = x.GetCustomAttributes(typeof (ActionNameAttribute), false);
+                    var overridenNames = x.GetCustomAttributes(typeof(ActionNameAttribute), false);
                     if (overridenNames.Any())
                     {
-                        var first = (ActionNameAttribute) overridenNames.FirstOrDefault();
+                        var first = (ActionNameAttribute)overridenNames.FirstOrDefault();
                         if (first != null) return first.Name;
                     }
                     return x.Name;

--- a/WebAPI.OutputCache/InvalidateCacheOutputAttribute.cs
+++ b/WebAPI.OutputCache/InvalidateCacheOutputAttribute.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net.Http;
-using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
 
 namespace WebAPI.OutputCache
@@ -11,7 +10,8 @@ namespace WebAPI.OutputCache
         private string _controller;
         private readonly string _methodName;
 
-        public InvalidateCacheOutputAttribute(string methodName) : this(methodName, null)
+        public InvalidateCacheOutputAttribute(string methodName)
+            : this(methodName, null)
         {
         }
 


### PR DESCRIPTION
Null reference exception is thrown when WebApi action results in exception and actionExecutedContext.Response ends up being null.
