### PR TITLE
Added support for no-cache

### DIFF
--- a/src/WebAPI.OutputCache/CacheOutputAttribute.cs
+++ b/src/WebAPI.OutputCache/CacheOutputAttribute.cs
@@ -20,6 +20,7 @@ namespace WebAPI.OutputCache
         public bool ExcludeQueryStringFromCacheKey { get; set; }
         public int ServerTimeSpan { get; set; }
         public int ClientTimeSpan { get; set; }
+		public bool NoCache { get; set; }
         private MediaTypeHeaderValue _responseMediaType;
 
         internal IModelQuery<DateTime, CacheTime> CacheTimeQuery;
@@ -159,7 +160,12 @@ namespace WebAPI.OutputCache
                                        };
 
                 response.Headers.CacheControl = cachecontrol;
-            }
+			}
+			else if (NoCache)
+			{
+				response.Headers.CacheControl = new CacheControlHeaderValue {NoCache = true};
+				response.Headers.Add("Pragma", "no-cache");
+			}
         }
 
         private static void SetEtag(HttpResponseMessage message, string etag)


### PR DESCRIPTION
I added a `NoCache` property to the `CacheOutputAttribute` class that, when set to true and neither `ClientTimeSpan` is set nor `MustRevalidate` is set, will create a `CacheControlHeaderValue` object with the `NoCache` property set to `true` in `ApplyCacheHeaders`.  It will also add a "Pragma" header with the value "no-cache".

Usage:

``` C#
        [CacheOutput(NoCache = true)]
        public ConfigInfo GetConfiguration(string id)
        {
            //...
        }

```
