### PR TITLE
Preserve stack trace when using CacheOutputAttribute

### DIFF
--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
@@ -253,13 +254,13 @@ namespace WebApi.OutputCache.V2
 
                 if (executedContext.Exception != null)
                 {
-                    throw executedContext.Exception;
+                    ExceptionDispatchInfo.Capture(executedContext.Exception).Throw();
                 }
             }
-            catch
+            catch (Exception e)
             {
                 actionContext.Response = null;
-                throw;
+                ExceptionDispatchInfo.Capture(e).Throw();
             }
 
             throw new InvalidOperationException(GetType().Name);


### PR DESCRIPTION
To preserve exceptions in an async method, we need to re-throw exceptions as follows:
ExceptionDispatchInfo.Capture(ex).Throw();
See http://stackoverflow.com/questions/57383/in-c-how-can-i-rethrow-innerexception-without-losing-stack-trace
