### PR TITLE
Added ExcludeAuthHeaderFromCacheKey to OutputCache attribute

### DIFF
--- a/src/WebApi.OutputCache.V2/AutoInvalidateCacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/AutoInvalidateCacheOutputAttribute.cs
@@ -20,7 +20,8 @@ namespace WebApi.OutputCache.V2
             if (actionExecutedContext.Response != null && !actionExecutedContext.Response.IsSuccessStatusCode) return;
             if (actionExecutedContext.ActionContext.Request.Method != HttpMethod.Post &&
                 actionExecutedContext.ActionContext.Request.Method != HttpMethod.Put &&
-                actionExecutedContext.ActionContext.Request.Method != HttpMethod.Delete) return;
+                actionExecutedContext.ActionContext.Request.Method != HttpMethod.Delete &&
+                actionExecutedContext.ActionContext.Request.Method.Method.ToLower() != "patch") return;
 
             var controller = actionExecutedContext.ActionContext.ControllerContext.ControllerDescriptor;
             var actions = FindAllGetMethods(controller.ControllerType, TryMatchType ? actionExecutedContext.ActionContext.ActionDescriptor.GetParameters() : null);


### PR DESCRIPTION
Sometimes the returned data varies for different users, depending on
their permissions. So I added the option ExcludeAuthHeaderFromCacheKey
to the OutputCache attribute to be able to vary the cache over different
values of the Authentication header.
