### PR TITLE
Added support for private cacheControl headers for CacheOutputAttribute

### DIFF
--- a/src/WebAPI.OutputCache/CacheOutputAttribute.cs
+++ b/src/WebAPI.OutputCache/CacheOutputAttribute.cs
@@ -18,13 +18,47 @@ namespace WebAPI.OutputCache
     public class CacheOutputAttribute : BaseCacheAttribute
     {
         protected static MediaTypeHeaderValue DefaultMediaType = new MediaTypeHeaderValue("application/json");
+
+        /// <summary>
+        /// Cache enabled only for requests when Thread.CurrentPrincipal is not set
+        /// </summary>
         public bool AnonymousOnly { get; set; }
+
+        /// <summary>
+        /// Corresponds to MustRevalidate HTTP header - indicates whether the origin server requires revalidation of a cache entry on any subsequent use when the cache entry becomes stale
+        /// </summary>
         public bool MustRevalidate { get; set; }
+
+        /// <summary>
+        /// Do not vary cache by querystring values
+        /// </summary>
         public bool ExcludeQueryStringFromCacheKey { get; set; }
+        
+        /// <summary>
+        /// How long response should be cached on the server side (in seconds)
+        /// </summary>
         public int ServerTimeSpan { get; set; }
+
+        /// <summary>
+        /// Corresponds to CacheControl MaxAge HTTP header (in seconds)
+        /// </summary>
         public int ClientTimeSpan { get; set; }
+
+        /// <summary>
+        /// Corresponds to CacheControl NoCache HTTP header
+        /// </summary>
 		public bool NoCache { get; set; }
+
+        /// <summary>
+        /// Corresponds to CacheControl Private HTTP header. Response can be cached by browser but not by intermediary cache
+        /// </summary>
+        public bool Private { get; set; }
+
+        /// <summary>
+        /// Class used to generate caching keys
+        /// </summary>
         public Type CacheKeyGenerator { get; set; }
+
         private MediaTypeHeaderValue _responseMediaType;
 
         internal IModelQuery<DateTime, CacheTime> CacheTimeQuery;
@@ -172,12 +206,13 @@ namespace WebAPI.OutputCache
 
         private void ApplyCacheHeaders(HttpResponseMessage response, CacheTime cacheTime)
         {
-            if (cacheTime.ClientTimeSpan > TimeSpan.Zero || MustRevalidate)
+            if (cacheTime.ClientTimeSpan > TimeSpan.Zero || MustRevalidate || Private)
             {
                 var cachecontrol = new CacheControlHeaderValue
                                        {
                                            MaxAge = cacheTime.ClientTimeSpan,
-                                           MustRevalidate = MustRevalidate
+                                           MustRevalidate = MustRevalidate,
+                                           Private = Private
                                        };
 
                 response.Headers.CacheControl = cachecontrol;

--- a/test/WebAPI.OutputCache.Tests/ClientSideTests.cs
+++ b/test/WebAPI.OutputCache.Tests/ClientSideTests.cs
@@ -109,6 +109,16 @@ namespace WebAPI.OutputCache.Tests
         }
 
         [Test]
+        public void maxage_private_true_headers_correct()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_c50_private").Result;
+
+            Assert.AreEqual(TimeSpan.FromSeconds(50), result.Headers.CacheControl.MaxAge);
+            Assert.IsTrue(result.Headers.CacheControl.Private);
+        }
+
+        [Test]
         public void maxage_mustrevalidate_headers_correct_with_cacheuntil()
         {
             var client = new HttpClient(_server);
@@ -157,6 +167,15 @@ namespace WebAPI.OutputCache.Tests
 
             Assert.IsTrue(Math.Round(new ThisYear(7, 31, 0, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds - ((TimeSpan)result.Headers.CacheControl.MaxAge).TotalSeconds) == 0);
             Assert.IsTrue(result.Headers.CacheControl.MustRevalidate);
+        }
+
+        [Test]
+        public void private_true_headers_correct()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_private").Result;
+
+            Assert.IsTrue(result.Headers.CacheControl.Private);
         }
 
         [TestFixtureTearDown]

--- a/test/WebAPI.OutputCache.Tests/TestControllers/SampleController.cs
+++ b/test/WebAPI.OutputCache.Tests/TestControllers/SampleController.cs
@@ -43,6 +43,18 @@ namespace WebAPI.OutputCache.Tests.TestControllers
             return "test";
         }
 
+        [CacheOutput(ClientTimeSpan = 50, Private = true)]
+        public string Get_c50_private()
+        {
+            return "test";
+        }
+
+        [CacheOutput(Private = true)]
+        public string Get_private()
+        {
+            return "test";
+        }
+
         [CacheOutput(ServerTimeSpan = 50)]
         public string Get_s50_exclude_fakecallback(int? id = null, string callback = null, string de = null)
         {

--- a/test/WebApi.OutputCache.V2.Tests/ClientSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ClientSideTests.cs
@@ -109,6 +109,16 @@ namespace WebApi.OutputCache.V2.Tests
         }
 
         [Test]
+        public void maxage_private_true_headers_correct()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_c50_private").Result;
+
+            Assert.AreEqual(TimeSpan.FromSeconds(50), result.Headers.CacheControl.MaxAge);
+            Assert.IsTrue(result.Headers.CacheControl.Private);
+        }
+
+        [Test]
         public void maxage_mustrevalidate_headers_correct_with_cacheuntil()
         {
             var client = new HttpClient(_server);
@@ -157,6 +167,15 @@ namespace WebApi.OutputCache.V2.Tests
 
             Assert.IsTrue(Math.Round(new ThisYear(7, 31, 0, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds - ((TimeSpan)result.Headers.CacheControl.MaxAge).TotalSeconds) == 0);
             Assert.IsTrue(result.Headers.CacheControl.MustRevalidate);
+        }
+
+        [Test]
+        public void private_true_headers_correct()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_private").Result;
+
+            Assert.IsTrue(result.Headers.CacheControl.Private);
         }
 
         [TestFixtureTearDown]

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
@@ -43,6 +43,18 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
             return "test";
         }
 
+        [CacheOutput(ClientTimeSpan = 50, Private = true)]
+        public string Get_c50_private()
+        {
+            return "test";
+        }
+
+        [CacheOutput(Private = true)]
+        public string Get_private()
+        {
+            return "test";
+        }
+
         [CacheOutput(ServerTimeSpan = 50)]
         public string Get_s50_exclude_fakecallback(int? id = null, string callback = null, string de = null)
         {


### PR DESCRIPTION
I have added support for cache-control:private directive via CacheOutputAttribute. 
I have also added comments taken from Readme to CacheOutputAttribute properties.
