### PR TITLE
Encoding Corrections

### DIFF
--- a/src/WebApi.OutputCache.V2/DefaultCacheKeyGenerator.cs
+++ b/src/WebApi.OutputCache.V2/DefaultCacheKeyGenerator.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Web.Http.Controllers;
 
 namespace WebApi.OutputCache.V2
@@ -44,7 +46,7 @@ namespace WebApi.OutputCache.V2
 
             if (parameters == "-") parameters = string.Empty;
 
-            var cachekey = string.Format("{0}{1}:{2}", key, parameters, mediaType.MediaType);
+            var cachekey = string.Format("{0}{1}:{2}", key, parameters, mediaType);
             return cachekey;
         }
 


### PR DESCRIPTION
- UTF8 is not always the encoding so take those cases into account.
- Cached requests were om-nom-nomming the content-type header's charset= parameter.
- Also added the character set to the cachekey because some optimized APIs will return UTF32 for logographic languages and UTF8 for latin-alphabet characters.

A description of the problem: when you have a response with utf-8 encoding (in my case a Web Api 2.0 Controller returning UTF-8 encoded json) the first response goes through fine but subsequent cached requests do not return the appropriate Content-Type header, because it removes the charset parameter.

IE. For the first request the response is:

``` csharp
actionExecutedContext.Response.Content.Headers.ContentType.ToString() == "application/json; charset=utf-8"
```

But only the application/json part (ContentType.MediaType) is being used/stored on the cache.

``` csharp
actionContext.Response.Content.Headers.ContentType.ToString() == "application/json"
```

This is a quick pull request fixing the issue.
