### PR TITLE
Fix for WebAPI2: Controller GET action with return type IHttpResultActio...

### DIFF
--- a/src/WebAPI.OutputCache/CacheOutputAttribute.cs
+++ b/src/WebAPI.OutputCache/CacheOutputAttribute.cs
@@ -92,8 +92,14 @@ namespace WebAPI.OutputCache
             if (negotiator != null && returnType != typeof(HttpResponseMessage))
             {
                 var negotiatedResult = negotiator.Negotiate(returnType, actionContext.Request, config.Formatters);
-                responseMediaType = negotiatedResult.MediaType;
-                responseMediaType.CharSet = Encoding.UTF8.HeaderName;
+
+                if (negotiatedResult != null)
+                {
+                    responseMediaType = negotiatedResult.MediaType;
+                    responseMediaType.CharSet = Encoding.UTF8.HeaderName;
+                }
+                else
+                    return DefaultMediaType;
             }
             else
             {


### PR DESCRIPTION
I have a controller GET action that returns IHttpResultAction decorated with CacheOutput attribute. When i try to execute the GET request i get the a System.NullReferenceException:

"Object reference not set to an instance of an object."
at WebApi.OutputCache.V2.CacheOutputAttribute.GetExpectedMediaType(HttpConfiguration config, ' HttpActionContext actionContext)

The problem is the content negotiator result is null when the return type of the action is a IHttpActionResult.
I have changed the GetExpectedMediaType in the CacheOutputAttribute class and it worked like a charm.

                if (negotiatedResult != null)
                {
                    responseMediaType = negotiatedResult.MediaType;
                    responseMediaType.CharSet = Encoding.UTF8.HeaderName;
                }
                else
                    return DefaultMediaType;