### PR TITLE
allow ApplyCacheHeaders to be overridden when inheriting this class

### DIFF
--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -221,7 +221,7 @@ namespace WebApi.OutputCache.V2
             ApplyCacheHeaders(actionExecutedContext.ActionContext.Response, cacheTime);
         }
 
-        private void ApplyCacheHeaders(HttpResponseMessage response, CacheTime cacheTime)
+        protected virtual void ApplyCacheHeaders(HttpResponseMessage response, CacheTime cacheTime)
         {
             if (cacheTime.ClientTimeSpan > TimeSpan.Zero || MustRevalidate || Private)
             {


### PR DESCRIPTION
I had a need to implement additional caching headers (specifically for setting the cache timeouts for our CDN) and the easiest way was to make this method overridable and subclass the CacheOutputAttribute class
