### PR TITLE
Added support for HTTP Range requests

### DIFF
--- a/src/WebAPI.OutputCache/CacheOutputAttribute.cs
+++ b/src/WebAPI.OutputCache/CacheOutputAttribute.cs
@@ -158,6 +158,13 @@ namespace WebAPI.OutputCache
             var responseEtag = WebApiCache.Get(cachekey + Constants.EtagKey) as string;
             if (responseEtag != null) SetEtag(actionContext.Response,  responseEtag);
 
+            var responseContentRange = WebApiCache.Get(cachekey + Constants.ContentRangeKey) as ContentRangeHeaderValue;
+            if (responseContentRange != null)
+            {
+                actionContext.Response.Content.Headers.ContentRange = responseContentRange;
+                actionContext.Response.StatusCode = HttpStatusCode.PartialContent;
+            }
+
             var cacheTime = CacheTimeQuery.Execute(DateTime.Now);
             ApplyCacheHeaders(actionContext.Response, cacheTime);
         }
@@ -196,6 +203,11 @@ namespace WebAPI.OutputCache
                                 WebApiCache.Add(cachekey + Constants.EtagKey,
                                                 actionExecutedContext.Response.Headers.ETag.Tag,
                                                 cacheTime.AbsoluteExpiration, baseKey);
+
+                                WebApiCache.Add(cachekey + Constants.ContentRangeKey,
+                                              actionExecutedContext.Response.Content.Headers.ContentRange,
+                                              cacheTime.AbsoluteExpiration, baseKey);
+
                             });
                     }
                 }

--- a/src/WebApi.OutputCache.Core/Constants.cs
+++ b/src/WebApi.OutputCache.Core/Constants.cs
@@ -4,5 +4,6 @@
     {
         public const string ContentTypeKey = ":response-ct";
         public const string EtagKey = ":response-etag";
+        public const string ContentRangeKey = ":response-cr";
     }
 }

--- a/src/WebApi.OutputCache.V2/DefaultCacheKeyGenerator.cs
+++ b/src/WebApi.OutputCache.V2/DefaultCacheKeyGenerator.cs
@@ -17,6 +17,7 @@ namespace WebApi.OutputCache.V2
             var action = context.ActionDescriptor.ActionName;
             var key = context.Request.GetConfiguration().CacheOutputConfiguration().MakeBaseCachekey(controller, action);
             var actionParameters = context.ActionArguments.Where(x => x.Value != null).Select(x => x.Key + "=" + GetValue(x.Value));
+            var rangeHeader = context.Request.Headers.Range;
 
             string parameters;
 
@@ -46,7 +47,7 @@ namespace WebApi.OutputCache.V2
 
             if (parameters == "-") parameters = string.Empty;
 
-            var cachekey = string.Format("{0}{1}:{2}", key, parameters, mediaType);
+            var cachekey = string.Format("{0}{1}{2}:{3}", key, parameters,rangeHeader, mediaType);
             return cachekey;
         }
 


### PR DESCRIPTION
The current version doesn't support range HTTP requests (http://svn.tools.ietf.org/svn/wg/httpbis/specs/rfc7233.html)

Current behavior : the cached requests doesn't contains response range header and the returned status code is 200. The range header isn't used when generating the cache key. Range : bytes=0:10 and Range : bytes=10:20 are identical for CacheOutput

expected behavior : the filter should return HTTP 206 status code with an appropriate Range header (same as the first request). The cache key should use request range header to generate the key.  
