### PR TITLE
Added ability to cache specified HTTP headers.

### DIFF
--- a/src/WebApi.OutputCache.Core/Constants.cs
+++ b/src/WebApi.OutputCache.Core/Constants.cs
@@ -4,5 +4,6 @@
     {
         public const string ContentTypeKey = ":response-ct";
         public const string EtagKey = ":response-etag";
+        public const string Headers = ":headers";
     }
 }

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -161,7 +161,6 @@ namespace WebApi.OutputCache.V2
                     {
                         var time = CacheTimeQuery.Execute(DateTime.Now);
                         var quickResponse = actionContext.Request.CreateResponse(HttpStatusCode.NotModified);
-                        AddCachedHeaders(quickResponse, cachekey);
                         if (responseHeaders != null) AddCachedHeaders(quickResponse, responseHeaders);
                         ApplyCacheHeaders(quickResponse, time);
                         actionContext.Response = quickResponse;


### PR DESCRIPTION
Great library, saves a ton of work. Don't know if this is something you're interested in adding but it was a necessity for one of our latest projects.

When a response was cached, it didn't send any of the custom headers we were using to hold the total row count, and the Link header we were using to send pagination links. So I added an OutputCacheAttribute parameter that will preserve headers you specify.

Ex.
[CacheOutput(ClientTimeSpan = 60, ServerTimeSpan = 60, HeadersToInclude = "X-Total,Link")]
