### PR TITLE
Fix IHttpActionResult and related changes

### DIFF
--- a/src/WebApi.OutputCache.Core/Cache/IApiOutputCache.cs
+++ b/src/WebApi.OutputCache.Core/Cache/IApiOutputCache.cs
@@ -6,11 +6,18 @@ namespace WebApi.OutputCache.Core.Cache
     public interface IApiOutputCache
     {
         void RemoveStartsWith(string key);
+
         T Get<T>(string key) where T : class;
+
+        [Obsolete("Use Get<T> instead")]
         object Get(string key);
+
         void Remove(string key);
+
         bool Contains(string key);
+
         void Add(string key, object o, DateTimeOffset expiration, string dependsOnKey = null);
+
         IEnumerable<string> AllKeys { get; }
     }
 }

--- a/src/WebApi.OutputCache.Core/Cache/MemoryCacheDefault.cs
+++ b/src/WebApi.OutputCache.Core/Cache/MemoryCacheDefault.cs
@@ -23,6 +23,7 @@ namespace WebApi.OutputCache.Core.Cache
             return o;
         }
 
+        [Obsolete("Use Get<T> instead")]
         public object Get(string key)
         {
             return Cache.Get(key);

--- a/src/WebApi.OutputCache.V2/AutoInvalidateCacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/AutoInvalidateCacheOutputAttribute.cs
@@ -20,7 +20,9 @@ namespace WebApi.OutputCache.V2
             if (actionExecutedContext.Response != null && !actionExecutedContext.Response.IsSuccessStatusCode) return;
             if (actionExecutedContext.ActionContext.Request.Method != HttpMethod.Post &&
                 actionExecutedContext.ActionContext.Request.Method != HttpMethod.Put &&
-                actionExecutedContext.ActionContext.Request.Method != HttpMethod.Delete) return;
+                actionExecutedContext.ActionContext.Request.Method != HttpMethod.Delete &&
+                actionExecutedContext.ActionContext.Request.Method.Method.ToLower() != "patch" &&
+                actionExecutedContext.ActionContext.Request.Method.Method.ToLower() != "merge") return;
 
             var controller = actionExecutedContext.ActionContext.ControllerContext.ControllerDescriptor;
             var actions = FindAllGetMethods(controller.ControllerType, TryMatchType ? actionExecutedContext.ActionContext.ActionDescriptor.GetParameters() : null);

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -99,9 +99,15 @@ namespace WebApi.OutputCache.V2
             var negotiator = config.Services.GetService(typeof(IContentNegotiator)) as IContentNegotiator;
             var returnType = actionContext.ActionDescriptor.ReturnType;
 
-            if (negotiator != null && returnType != typeof(HttpResponseMessage))
+            if (negotiator != null && returnType != typeof(HttpResponseMessage) && (returnType != typeof(IHttpActionResult) || typeof(IHttpActionResult).IsAssignableFrom(returnType)))
             {
                 var negotiatedResult = negotiator.Negotiate(returnType, actionContext.Request, config.Formatters);
+
+                if (negotiatedResult == null)
+                {
+                    return DefaultMediaType;
+                }
+
                 responseMediaType = negotiatedResult.MediaType;
                 if (string.IsNullOrWhiteSpace(responseMediaType.CharSet))
                 {
@@ -113,8 +119,7 @@ namespace WebApi.OutputCache.V2
                 if (actionContext.Request.Headers.Accept != null)
                 {
                     responseMediaType = actionContext.Request.Headers.Accept.FirstOrDefault();
-                    if (responseMediaType == null ||
-                        !config.Formatters.Any(x => x.SupportedMediaTypes.Contains(responseMediaType)))
+                    if (responseMediaType == null || !config.Formatters.Any(x => x.SupportedMediaTypes.Contains(responseMediaType)))
                     {
                         return DefaultMediaType;
                     }

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -150,7 +150,7 @@ namespace WebApi.OutputCache.V2
 
             if (actionContext.Request.Headers.IfNoneMatch != null)
             {
-                var etag = _webApiCache.Get(cachekey + Constants.EtagKey) as string;
+                var etag = _webApiCache.Get<string>(cachekey + Constants.EtagKey);
                 if (etag != null)
                 {
                     if (actionContext.Request.Headers.IfNoneMatch.Any(x => x.Tag ==  etag))
@@ -164,16 +164,16 @@ namespace WebApi.OutputCache.V2
                 }
             }
 
-            var val = _webApiCache.Get(cachekey) as byte[];
+            var val = _webApiCache.Get<byte[]>(cachekey);
             if (val == null) return;
 
-            var contenttype = _webApiCache.Get(cachekey + Constants.ContentTypeKey) as MediaTypeHeaderValue ?? new MediaTypeHeaderValue(cachekey.Split(new[] {':'},2)[1]);
+            var contenttype = _webApiCache.Get<MediaTypeHeaderValue>(cachekey + Constants.ContentTypeKey) ?? new MediaTypeHeaderValue(cachekey.Split(new[] {':'},2)[1]);
 
             actionContext.Response = actionContext.Request.CreateResponse();
             actionContext.Response.Content = new ByteArrayContent(val);
 
             actionContext.Response.Content.Headers.ContentType = contenttype;
-            var responseEtag = _webApiCache.Get(cachekey + Constants.EtagKey) as string;
+            var responseEtag = _webApiCache.Get<string>(cachekey + Constants.EtagKey);
             if (responseEtag != null) SetEtag(actionContext.Response,  responseEtag);
 
             var cacheTime = CacheTimeQuery.Execute(DateTime.Now);

--- a/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
@@ -237,7 +237,7 @@ namespace WebApi.OutputCache.V2.Tests
         public void etag_match_304_if_none_match()
         {
             _cache.Setup(x => x.Contains(It.Is<string>(i => i.Contains("etag_match_304")))).Returns(true);
-            _cache.Setup(x => x.Get(It.Is<string>(i => i.Contains("etag_match_304") && i.Contains(Constants.EtagKey))))
+            _cache.Setup(x => x.Get<string>(It.Is<string>(i => i.Contains("etag_match_304") && i.Contains(Constants.EtagKey))))
                   .Returns(@"""abc""");
 
             var client = new HttpClient(_server);
@@ -254,8 +254,9 @@ namespace WebApi.OutputCache.V2.Tests
         public void etag_not_match_304_if_none_match()
         {
             _cache.Setup(x => x.Contains(It.Is<string>(i => i.Contains("etag_match_304")))).Returns(true);
-            _cache.Setup(x => x.Get(It.Is<string>(i => i.Contains("etag_match_304") && i.Contains(Constants.EtagKey))))
-                  .Returns((object)new EntityTagHeaderValue(@"""abcdef"""));
+            _cache.Setup(x => x.Get<byte[]>(It.IsAny<string>())).Returns((byte[])null);
+            _cache.Setup(x => x.Get<string>(It.Is<string>(i => i.Contains("etag_match_304") && i.Contains(Constants.EtagKey))))
+                  .Returns(@"""abcdef""");
 
             var client = new HttpClient(_server);
             var req = new HttpRequestMessage(HttpMethod.Get, _url + "etag_match_304");

--- a/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
@@ -267,6 +267,30 @@ namespace WebApi.OutputCache.V2.Tests
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
         }
 
+        [Test]
+        public void can_handle_ihttpactionresult_with_default_media_type()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "Get_ihttpactionresult").Result;
+
+            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_ihttpactionresult:application/json; charset=utf-8")), Times.Exactly(2));
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_ihttpactionresult"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_ihttpactionresult:application/json; charset=utf-8"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "sample-get_ihttpactionresult")), Times.Once());
+        }
+
+        [Test]
+        public void can_handle_ihttpactionresult_with_non_default_media_type()
+        {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Get_ihttpactionresult");
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/xml"));
+            var result = client.SendAsync(req).Result;
+
+            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "sample-get_ihttpactionresult:text/xml; charset=utf-8")), Times.Exactly(2));
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_ihttpactionresult"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "sample-get_ihttpactionresult:text/xml; charset=utf-8"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "sample-get_ihttpactionresult")), Times.Once());
+        }
+
 
         //[Test]
         //public void must_add_querystring_to_cache_params()

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
@@ -146,5 +146,11 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
         {
             //do nothing
         }
+
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100)]
+        public IHttpActionResult Get_ihttpactionresult()
+        {
+            return Ok("value");
+        }
     }
 }


### PR DESCRIPTION
 - improve the handling of `IHttpActionResult`. fixes #105 and #99
 - obsolete `Get` in favor of `Get<T>` on `IApiOutputCache`
 - added PATCH and MERGE to `AutoInvalidateCacheOutputAttribute`

Thanks to @mackayj

Suppresses #103 and #104 