### PR TITLE
Fix bug when cache expires halfway during a request.

### DIFF
--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -167,7 +167,7 @@ namespace WebApi.OutputCache.V2
             var val = _webApiCache.Get<byte[]>(cachekey);
             if (val == null) return;
 
-            var contenttype = _webApiCache.Get<MediaTypeHeaderValue>(cachekey + Constants.ContentTypeKey) ?? new MediaTypeHeaderValue(cachekey.Split(new[] {':'},2)[1]);
+            var contenttype = _webApiCache.Get<MediaTypeHeaderValue>(cachekey + Constants.ContentTypeKey) ?? new MediaTypeHeaderValue(cachekey.Split(new[] { ':' }, 2)[1].Split(';')[0]);
 
             actionContext.Response = actionContext.Request.CreateResponse();
             actionContext.Response.Content = new ByteArrayContent(val);

--- a/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
@@ -293,6 +293,19 @@ namespace WebApi.OutputCache.V2.Tests
         }
 
 
+        [Test]
+        public void can_handle_media_type_when_cache_has_expired_during_request()
+        {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Get_ihttpactionresult");
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/xml"));
+            _cache.Setup(o => o.Contains(It.IsAny<string>())).Returns(true);
+            _cache.Setup(o => o.Get<MediaTypeHeaderValue>(It.Is((string key) => key.Contains(Constants.ContentTypeKey)))).Returns((MediaTypeHeaderValue)null);
+            var result = client.SendAsync(req).Result;
+            Assert.That(result.IsSuccessStatusCode, Is.True);
+        }
+
+
         //[Test]
         //public void must_add_querystring_to_cache_params()
         //{


### PR DESCRIPTION
Found an intermittent bug caused by: When the server side cache provider expires during the request.
We get the error 
> MediaTypeHeaderValue System.FormatException: The format of value 'application/json; charset=utf-8' is invalid.

