### PR TITLE
Update MemoryCacheDefault.cs

### DIFF
--- a/src/WebApi.OutputCache.Core/Cache/MemoryCacheDefault.cs
+++ b/src/WebApi.OutputCache.Core/Cache/MemoryCacheDefault.cs
@@ -13,7 +13,10 @@ namespace WebApi.OutputCache.Core.Cache
         {
             lock (Cache)
             {
-                Cache.Remove(key);
+                foreach (string key2Remove in AllKeys.Where(x => x.StartsWith(key)).ToList())
+                {
+                    Cache.Remove(key2Remove);
+                }
             }
         }
 


### PR DESCRIPTION
RemoveStartsWith had a bug. It had the same functionality as Remove method