### PR TITLE
Included LastModified in response headers

### DIFF
--- a/src/WebApi.OutputCache.Core/Constants.cs
+++ b/src/WebApi.OutputCache.Core/Constants.cs
@@ -4,5 +4,6 @@
     {
         public const string ContentTypeKey = ":response-ct";
         public const string EtagKey = ":response-etag";
+        public const string GenerationTimestampKey = ":response-generationtimestamp";
     }
 }

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -195,6 +195,7 @@ namespace WebApi.OutputCache.V2
             if (val == null) return;
 
             var contenttype = _webApiCache.Get<MediaTypeHeaderValue>(cachekey + Constants.ContentTypeKey) ?? responseMediaType;
+            var contentGenerationTimestamp = DateTimeOffset.Parse(_webApiCache.Get<string>(cachekey + Constants.GenerationTimestampKey));
 
             actionContext.Response = actionContext.Request.CreateResponse();
             actionContext.Response.Content = new ByteArrayContent(val);
@@ -204,7 +205,7 @@ namespace WebApi.OutputCache.V2
             if (responseEtag != null) SetEtag(actionContext.Response,  responseEtag);
 
             var cacheTime = CacheTimeQuery.Execute(DateTime.Now);
-            ApplyCacheHeaders(actionContext.Response, cacheTime);
+            ApplyCacheHeaders(actionContext.Response, cacheTime, contentGenerationTimestamp);
         }
 
         public override async Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
@@ -213,8 +214,9 @@ namespace WebApi.OutputCache.V2
 
             if (!IsCachingAllowed(actionExecutedContext.ActionContext, AnonymousOnly)) return;
 
-            var cacheTime = CacheTimeQuery.Execute(DateTime.Now);
-            if (cacheTime.AbsoluteExpiration > DateTime.Now)
+            var actionExecutionTimestamp = DateTimeOffset.Now;
+            var cacheTime = CacheTimeQuery.Execute(actionExecutionTimestamp.DateTime);
+            if (cacheTime.AbsoluteExpiration > actionExecutionTimestamp)
             {
                 var httpConfig = actionExecutedContext.Request.GetConfiguration();
                 var config = httpConfig.CacheOutputConfiguration();
@@ -251,14 +253,19 @@ namespace WebApi.OutputCache.V2
                         _webApiCache.Add(cachekey + Constants.EtagKey,
                                         etag,
                                         cacheTime.AbsoluteExpiration, baseKey);
+
+
+                        _webApiCache.Add(cachekey + Constants.GenerationTimestampKey,
+                                        actionExecutionTimestamp.ToString(),
+                                        cacheTime.AbsoluteExpiration, baseKey);
                     }
                 }
             }
 
-            ApplyCacheHeaders(actionExecutedContext.ActionContext.Response, cacheTime);
+            ApplyCacheHeaders(actionExecutedContext.ActionContext.Response, cacheTime, actionExecutionTimestamp);
         }
 
-        protected virtual void ApplyCacheHeaders(HttpResponseMessage response, CacheTime cacheTime)
+        protected virtual void ApplyCacheHeaders(HttpResponseMessage response, CacheTime cacheTime, DateTimeOffset? contentGenerationTimestamp = null)
         {
             if (cacheTime.ClientTimeSpan > TimeSpan.Zero || MustRevalidate || Private)
             {
@@ -276,6 +283,10 @@ namespace WebApi.OutputCache.V2
             {
                 response.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true };
                 response.Headers.Add("Pragma", "no-cache");
+            }
+            if ((response.Content != null) && contentGenerationTimestamp.HasValue)
+            {
+                response.Content.Headers.LastModified = contentGenerationTimestamp.Value;
             }
         }
 


### PR DESCRIPTION
This is a solution for #201. 

Implemented logic to keep record of the timestamp when a response content was generated and use it as the Last-Modified response header.
The implementation is quite basic and tried to reduce the impact, however it has a breaking change on the signature of `ApplyCacheHeaders` method.
And it could be improved, depending how you'd like to expose this, by:
* Using an additional boolean property in the `CacheOutputAttribute` to control whether the header is included or not
* Trying to avoid inline serialization / deserialization of the timestamp (by either changing the restriction in the `Get<>` of the `IApiOutputCache`, or using a wrapper object which could also help with the #41)

Additionally, I can include in the Pull Request some changes on the Demo application to support the CORS request that the scenario will probably require (and some other tweaks on it to make it easier for any developer to use it)