### PR TITLE
Cache Key generation enhancements

### DIFF
--- a/src/WebApi.OutputCache.V2/PerUserCacheKeyGenerator.cs
+++ b/src/WebApi.OutputCache.V2/PerUserCacheKeyGenerator.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Http.Headers;
+using System.Web.Http.Controllers;
+
+namespace WebApi.OutputCache.V2
+{
+    public class PerUserCacheKeyGenerator : DefaultCacheKeyGenerator
+    {
+        public override string MakeCacheKey(HttpActionContext context, MediaTypeHeaderValue mediaType, bool excludeQueryString = false)
+        {
+            var baseKey = MakeBaseKey(context);
+            var parameters = FormatParameters(context, excludeQueryString);
+            var userIdentity = FormatUserIdentity(context);
+
+            return string.Format("{0}{1}:{2}:{3}", baseKey, parameters, userIdentity, mediaType);
+        }
+
+        protected virtual string FormatUserIdentity(HttpActionContext context)
+        {
+            return context.RequestContext.Principal.Identity.Name.ToLower();
+        }
+    }
+}

--- a/src/WebApi.OutputCache.V2/WebApi.OutputCache.V2.csproj
+++ b/src/WebApi.OutputCache.V2/WebApi.OutputCache.V2.csproj
@@ -63,6 +63,7 @@
     <Compile Include="ICacheKeyGenerator.cs" />
     <Compile Include="IgnoreCacheOutputAttribute.cs" />
     <Compile Include="InvalidateCacheOutputAttribute.cs" />
+    <Compile Include="PerUserCacheKeyGenerator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CacheOutputAttribute.cs" />
     <Compile Include="TimeAttributes\CacheOutputUntilCacheAttribute.cs" />

--- a/test/WebApi.OutputCache.V2.Tests/CacheKeyGenerationTestsBase.cs
+++ b/test/WebApi.OutputCache.V2.Tests/CacheKeyGenerationTestsBase.cs
@@ -1,0 +1,60 @@
+﻿using NUnit.Framework;
+using System;
+using System.Net.Http.Headers;
+using System.Web.Http.Controllers;
+
+namespace WebApi.OutputCache.V2.Tests
+{
+    /// <summary>
+    /// Base class for implementing tests for the generation of cache keys (meaning: implementations of the <see cref="ICacheKeyGenerator"/>
+    /// </summary>
+    public abstract class CacheKeyGenerationTestsBase<TCacheKeyGenerator> where TCacheKeyGenerator : ICacheKeyGenerator
+    {
+        private const string ArgumentKey = "filterExpression";
+        private const string ArgumentValue = "val";
+        protected HttpActionContext context;
+        protected MediaTypeHeaderValue mediaType;
+        protected Uri requestUri;
+        protected TCacheKeyGenerator cacheKeyGenerator;
+        protected string BaseCacheKey;
+
+        [SetUp]
+        public virtual void Setup()
+        {
+            requestUri = new Uri("http://localhost:8080/cacheKeyGeneration?filter=val");
+            var controllerType = typeof(TestControllers.CacheKeyGenerationController);
+            var actionMethodInfo = controllerType.GetMethod("Get");
+            var controllerDescriptor = new HttpControllerDescriptor() { ControllerType = controllerType };
+            var actionDescriptor = new ReflectedHttpActionDescriptor(controllerDescriptor, actionMethodInfo);
+            var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Get, requestUri.AbsoluteUri);
+
+            context = new HttpActionContext(
+                new HttpControllerContext() { ControllerDescriptor = controllerDescriptor, Request = request },
+                actionDescriptor
+            );
+            mediaType = new MediaTypeHeaderValue("application/json");
+
+            BaseCacheKey = new CacheOutputConfiguration(null).MakeBaseCachekey((TestControllers.CacheKeyGenerationController c) => c.Get(String.Empty));
+            cacheKeyGenerator = BuildCacheKeyGenerator();
+        }
+
+        protected abstract TCacheKeyGenerator BuildCacheKeyGenerator();
+
+        protected virtual void AssertCacheKeysBasicFormat(string cacheKey)
+        {
+            Assert.IsNotNull(cacheKey);
+            StringAssert.StartsWith(BaseCacheKey, cacheKey, "Key does not start with BaseKey");
+            StringAssert.EndsWith(mediaType.ToString(), cacheKey, "Key does not end with MediaType");
+        }
+
+        protected void AddActionArgumentsToContext()
+        {
+            context.ActionArguments.Add(ArgumentKey, ArgumentValue);
+        }
+
+        protected string FormatActionArgumentsForKeyAssertion()
+        {
+            return String.Format("{0}={1}", ArgumentKey, ArgumentValue);
+        }
+    }
+}

--- a/test/WebApi.OutputCache.V2.Tests/DefaultCacheKeyGeneratorTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/DefaultCacheKeyGeneratorTests.cs
@@ -6,46 +6,11 @@ using System.Web.Http.Controllers;
 namespace WebApi.OutputCache.V2.Tests
 {
     [TestFixture]
-    public class DefaultCacheKeyGeneratorTests
+    public class DefaultCacheKeyGeneratorTests : CacheKeyGenerationTestsBase<DefaultCacheKeyGenerator>
     {
-        private const string ArgumentKey = "filterExpression";
-        private const string ArgumentValue = "val";
-        private HttpActionContext context;
-        private MediaTypeHeaderValue mediaType;
-        private Uri requestUri;
-        private DefaultCacheKeyGenerator cacheKeyGenerator;
-        private string BaseCacheKey;
-
-        [SetUp]
-        public void Setup()
+        protected override DefaultCacheKeyGenerator BuildCacheKeyGenerator()
         {
-            requestUri = new Uri("http://localhost:8080/cacheKeyGeneration?filter=val");
-            var controllerType = typeof(TestControllers.CacheKeyGenerationController);
-            var actionMethodInfo = controllerType.GetMethod("Get");
-            var controllerDescriptor = new HttpControllerDescriptor() { ControllerType = controllerType };
-            var actionDescriptor = new ReflectedHttpActionDescriptor(controllerDescriptor, actionMethodInfo);
-            var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Get, requestUri.AbsoluteUri);
-
-            context = new HttpActionContext(
-                new HttpControllerContext() { ControllerDescriptor = controllerDescriptor, Request = request },
-                actionDescriptor
-            );
-            mediaType = new MediaTypeHeaderValue("application/json");
-
-            cacheKeyGenerator = new DefaultCacheKeyGenerator();
-            BaseCacheKey = new CacheOutputConfiguration(null).MakeBaseCachekey((TestControllers.CacheKeyGenerationController c) => c.Get(String.Empty));
-        }
-
-        private void AssertCacheKeysBasicFormat(string cacheKey)
-        {
-            Assert.IsNotNull(cacheKey);
-            StringAssert.StartsWith(BaseCacheKey, cacheKey, "Key does not start with BaseKey");
-            StringAssert.EndsWith(mediaType.ToString(), cacheKey, "Key does not end with MediaType");
-        }
-
-        private void AddActionArgumentsToContext() 
-        {
-            context.ActionArguments.Add(ArgumentKey, ArgumentValue);
+            return new DefaultCacheKeyGenerator();
         }
 
         [Test]
@@ -73,7 +38,7 @@ namespace WebApi.OutputCache.V2.Tests
             var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, false);
 
             AssertCacheKeysBasicFormat(cacheKey);
-            Assert.AreEqual(String.Format("{0}-{1}={2}&{3}:{4}", BaseCacheKey, ArgumentKey, ArgumentValue, requestUri.Query.Substring(1), mediaType), cacheKey, "Key does not match expected <BaseKey>-<Arguments>&<QueryString>:<MediaType>");
+            Assert.AreEqual(String.Format("{0}-{1}&{2}:{3}", BaseCacheKey, FormatActionArgumentsForKeyAssertion(), requestUri.Query.Substring(1), mediaType), cacheKey, "Key does not match expected <BaseKey>-<Arguments>&<QueryString>:<MediaType>");
         }
 
         [Test]
@@ -83,7 +48,7 @@ namespace WebApi.OutputCache.V2.Tests
             var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, true);
 
             AssertCacheKeysBasicFormat(cacheKey);
-            Assert.AreEqual(String.Format("{0}-{1}={2}:{3}", BaseCacheKey, ArgumentKey, ArgumentValue, mediaType), cacheKey, "Key does not match expected <BaseKey>-<Arguments>:<MediaType>");
+            Assert.AreEqual(String.Format("{0}-{1}:{2}", BaseCacheKey, FormatActionArgumentsForKeyAssertion(), mediaType), cacheKey, "Key does not match expected <BaseKey>-<Arguments>:<MediaType>");
         }
     }
 }

--- a/test/WebApi.OutputCache.V2.Tests/DefaultCacheKeyGeneratorTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/DefaultCacheKeyGeneratorTests.cs
@@ -1,0 +1,89 @@
+﻿using NUnit.Framework;
+using System;
+using System.Net.Http.Headers;
+using System.Web.Http.Controllers;
+
+namespace WebApi.OutputCache.V2.Tests
+{
+    [TestFixture]
+    public class DefaultCacheKeyGeneratorTests
+    {
+        private const string ArgumentKey = "filterExpression";
+        private const string ArgumentValue = "val";
+        private HttpActionContext context;
+        private MediaTypeHeaderValue mediaType;
+        private Uri requestUri;
+        private DefaultCacheKeyGenerator cacheKeyGenerator;
+        private string BaseCacheKey;
+
+        [SetUp]
+        public void Setup()
+        {
+            requestUri = new Uri("http://localhost:8080/cacheKeyGeneration?filter=val");
+            var controllerType = typeof(TestControllers.CacheKeyGenerationController);
+            var actionMethodInfo = controllerType.GetMethod("Get");
+            var controllerDescriptor = new HttpControllerDescriptor() { ControllerType = controllerType };
+            var actionDescriptor = new ReflectedHttpActionDescriptor(controllerDescriptor, actionMethodInfo);
+            var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Get, requestUri.AbsoluteUri);
+
+            context = new HttpActionContext(
+                new HttpControllerContext() { ControllerDescriptor = controllerDescriptor, Request = request },
+                actionDescriptor
+            );
+            mediaType = new MediaTypeHeaderValue("application/json");
+
+            cacheKeyGenerator = new DefaultCacheKeyGenerator();
+            BaseCacheKey = new CacheOutputConfiguration(null).MakeBaseCachekey((TestControllers.CacheKeyGenerationController c) => c.Get(String.Empty));
+        }
+
+        private void AssertCacheKeysBasicFormat(string cacheKey)
+        {
+            Assert.IsNotNull(cacheKey);
+            StringAssert.StartsWith(BaseCacheKey, cacheKey, "Key does not start with BaseKey");
+            StringAssert.EndsWith(mediaType.ToString(), cacheKey, "Key does not end with MediaType");
+        }
+
+        private void AddActionArgumentsToContext() 
+        {
+            context.ActionArguments.Add(ArgumentKey, ArgumentValue);
+        }
+
+        [Test]
+        public void NoParametersIncludeQueryString_ShouldReturnBaseKeyAndQueryStringAndMediaTypeConcatenated()
+        {
+            var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, false);
+
+            AssertCacheKeysBasicFormat(cacheKey);
+            Assert.AreEqual(String.Format("{0}-{1}:{2}", BaseCacheKey, requestUri.Query.Substring(1), mediaType), cacheKey, "Key does not match expected <BaseKey>-<QueryString>:<MediaType>");
+        }
+
+        [Test]
+        public void NoParametersExcludeQueryString_ShouldReturnBaseKeyAndMediaTypeConcatenated()
+        {
+            var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, true);
+
+            AssertCacheKeysBasicFormat(cacheKey);
+            Assert.AreEqual(String.Format("{0}:{1}", BaseCacheKey, mediaType), cacheKey, "Key does not match expected <BaseKey>:<MediaType>");
+        }
+
+        [Test]
+        public void WithParametersIncludeQueryString_ShouldReturnBaseKeyAndArgumentsAndQueryStringAndMediaTypeConcatenated()
+        {
+            AddActionArgumentsToContext();
+            var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, false);
+
+            AssertCacheKeysBasicFormat(cacheKey);
+            Assert.AreEqual(String.Format("{0}-{1}={2}&{3}:{4}", BaseCacheKey, ArgumentKey, ArgumentValue, requestUri.Query.Substring(1), mediaType), cacheKey, "Key does not match expected <BaseKey>-<Arguments>&<QueryString>:<MediaType>");
+        }
+
+        [Test]
+        public void WithParametersExcludeQueryString_ShouldReturnBaseKeyAndArgumentsAndMediaTypeConcatenated()
+        {
+            AddActionArgumentsToContext();
+            var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, true);
+
+            AssertCacheKeysBasicFormat(cacheKey);
+            Assert.AreEqual(String.Format("{0}-{1}={2}:{3}", BaseCacheKey, ArgumentKey, ArgumentValue, mediaType), cacheKey, "Key does not match expected <BaseKey>-<Arguments>:<MediaType>");
+        }
+    }
+}

--- a/test/WebApi.OutputCache.V2.Tests/DefaultCacheKeyGeneratorTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/DefaultCacheKeyGeneratorTests.cs
@@ -1,7 +1,5 @@
 ﻿using NUnit.Framework;
 using System;
-using System.Net.Http.Headers;
-using System.Web.Http.Controllers;
 
 namespace WebApi.OutputCache.V2.Tests
 {
@@ -19,7 +17,8 @@ namespace WebApi.OutputCache.V2.Tests
             var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, false);
 
             AssertCacheKeysBasicFormat(cacheKey);
-            Assert.AreEqual(String.Format("{0}-{1}:{2}", BaseCacheKey, requestUri.Query.Substring(1), mediaType), cacheKey, "Key does not match expected <BaseKey>-<QueryString>:<MediaType>");
+            Assert.AreEqual(String.Format("{0}-{1}:{2}", BaseCacheKey, requestUri.Query.Substring(1), mediaType), cacheKey,
+                "Key does not match expected <BaseKey>-<QueryString>:<MediaType>");
         }
 
         [Test]
@@ -28,7 +27,8 @@ namespace WebApi.OutputCache.V2.Tests
             var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, true);
 
             AssertCacheKeysBasicFormat(cacheKey);
-            Assert.AreEqual(String.Format("{0}:{1}", BaseCacheKey, mediaType), cacheKey, "Key does not match expected <BaseKey>:<MediaType>");
+            Assert.AreEqual(String.Format("{0}:{1}", BaseCacheKey, mediaType), cacheKey,
+                "Key does not match expected <BaseKey>:<MediaType>");
         }
 
         [Test]
@@ -38,7 +38,8 @@ namespace WebApi.OutputCache.V2.Tests
             var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, false);
 
             AssertCacheKeysBasicFormat(cacheKey);
-            Assert.AreEqual(String.Format("{0}-{1}&{2}:{3}", BaseCacheKey, FormatActionArgumentsForKeyAssertion(), requestUri.Query.Substring(1), mediaType), cacheKey, "Key does not match expected <BaseKey>-<Arguments>&<QueryString>:<MediaType>");
+            Assert.AreEqual(String.Format("{0}-{1}&{2}:{3}", BaseCacheKey, FormatActionArgumentsForKeyAssertion(), requestUri.Query.Substring(1), mediaType), cacheKey,
+                "Key does not match expected <BaseKey>-<Arguments>&<QueryString>:<MediaType>");
         }
 
         [Test]
@@ -48,7 +49,8 @@ namespace WebApi.OutputCache.V2.Tests
             var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, true);
 
             AssertCacheKeysBasicFormat(cacheKey);
-            Assert.AreEqual(String.Format("{0}-{1}:{2}", BaseCacheKey, FormatActionArgumentsForKeyAssertion(), mediaType), cacheKey, "Key does not match expected <BaseKey>-<Arguments>:<MediaType>");
+            Assert.AreEqual(String.Format("{0}-{1}:{2}", BaseCacheKey, FormatActionArgumentsForKeyAssertion(), mediaType), cacheKey,
+                "Key does not match expected <BaseKey>-<Arguments>:<MediaType>");
         }
     }
 }

--- a/test/WebApi.OutputCache.V2.Tests/PerUserCacheKeyGeneratorTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/PerUserCacheKeyGeneratorTests.cs
@@ -1,0 +1,71 @@
+﻿using NUnit.Framework;
+using System;
+using System.Security.Principal;
+
+namespace WebApi.OutputCache.V2.Tests
+{
+    [TestFixture]
+    public class PerUserCacheKeyGeneratorTests : CacheKeyGenerationTestsBase<PerUserCacheKeyGenerator>
+    {
+        private const string UserIdentityName = "SomeUserIDon'tMind";
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+            context.RequestContext.Principal = new GenericPrincipal(new GenericIdentity(UserIdentityName), new string[0]);
+        }
+
+        protected override PerUserCacheKeyGenerator BuildCacheKeyGenerator()
+        {
+            return new PerUserCacheKeyGenerator();
+        }
+
+        private string FormatUserIdentityForAssertion() 
+        {
+            return UserIdentityName.ToLower();
+        }
+
+        [Test]
+        public void NoParametersIncludeQueryString_ShouldReturnBaseKeyAndQueryStringAndUserIdentityAndMediaTypeConcatenated()
+        {
+            var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, false);
+
+            AssertCacheKeysBasicFormat(cacheKey);
+            Assert.AreEqual(String.Format("{0}-{1}:{2}:{3}", BaseCacheKey, requestUri.Query.Substring(1), FormatUserIdentityForAssertion(), mediaType), cacheKey, 
+                "Key does not match expected <BaseKey>-<QueryString>:<UserIdentity>:<MediaType>");
+        }
+
+        [Test]
+        public void NoParametersExcludeQueryString_ShouldReturnBaseKeyAndUserIdentityAndMediaTypeConcatenated()
+        {
+            var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, true);
+
+            AssertCacheKeysBasicFormat(cacheKey);
+            Assert.AreEqual(String.Format("{0}:{1}:{2}", BaseCacheKey, FormatUserIdentityForAssertion(), mediaType), cacheKey,
+                "Key does not match expected <BaseKey>:<UserIdentity>:<MediaType>");
+        }
+
+        [Test]
+        public void WithParametersIncludeQueryString_ShouldReturnBaseKeyAndArgumentsAndQueryStringAndUserIdentityAndMediaTypeConcatenated()
+        {
+            AddActionArgumentsToContext();
+            var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, false);
+
+            AssertCacheKeysBasicFormat(cacheKey);
+            Assert.AreEqual(String.Format("{0}-{1}&{2}:{3}:{4}", BaseCacheKey, FormatActionArgumentsForKeyAssertion(), requestUri.Query.Substring(1), FormatUserIdentityForAssertion(), mediaType), cacheKey,
+                "Key does not match expected <BaseKey>-<Arguments>&<QueryString>:<UserIdentity>:<MediaType>");
+        }
+
+        [Test]
+        public void WithParametersExcludeQueryString_ShouldReturnBaseKeyAndArgumentsAndUserIdentityAndMediaTypeConcatenated()
+        {
+            AddActionArgumentsToContext();
+            var cacheKey = cacheKeyGenerator.MakeCacheKey(context, mediaType, true);
+
+            AssertCacheKeysBasicFormat(cacheKey);
+            Assert.AreEqual(String.Format("{0}-{1}:{2}:{3}", BaseCacheKey, FormatActionArgumentsForKeyAssertion(), FormatUserIdentityForAssertion(), mediaType), cacheKey,
+                "Key does not match expected <BaseKey>-<Arguments>:<UserIdentity>:<MediaType>");
+        }
+    }
+}

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/CacheKeyGenerationController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/CacheKeyGenerationController.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+
+namespace WebApi.OutputCache.V2.Tests.TestControllers
+{
+    /// <summary>
+    /// Controller needed for generating the <see cref="System.Web.Http.Controllers.HttpActionContext" /> needed for testing the <see cref="ICacheKeyGenerator"/> implementations
+    /// </summary>
+    [RoutePrefix("cacheKeyGeneration")]
+    public class CacheKeyGenerationController : ApiController
+    {
+        private readonly string[] Values = new string[] { "first", "second", "third" };
+
+        [Route("")]
+        public IEnumerable<string> Get([FromUri(Name="filter")]string filterExpression)
+        {
+            return String.IsNullOrWhiteSpace(filterExpression) ? Values : Values.Where(x => x.Contains(filterExpression));
+        }
+
+        [Route("{index}")]
+        public string GetByIndex(int index)
+        {
+            return Values[index];
+        }
+    }
+}

--- a/test/WebApi.OutputCache.V2.Tests/WebApi.OutputCache.V2.Tests.csproj
+++ b/test/WebApi.OutputCache.V2.Tests/WebApi.OutputCache.V2.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ConnegTests.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="DefaultCacheKeyGeneratorTests.cs" />
     <Compile Include="InlineInvalidateTests.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -95,6 +96,7 @@
     <Compile Include="TestControllers\AutoInvalidateController.cs" />
     <Compile Include="TestControllers\AutoInvalidateWithTypeController.cs" />
     <Compile Include="TestControllers\CacheKeyController.cs" />
+    <Compile Include="TestControllers\CacheKeyGenerationController.cs" />
     <Compile Include="TestControllers\IgnoreController.cs" />
     <Compile Include="TestControllers\InlineInvalidateController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/WebApi.OutputCache.V2.Tests/WebApi.OutputCache.V2.Tests.csproj
+++ b/test/WebApi.OutputCache.V2.Tests/WebApi.OutputCache.V2.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ConnegTests.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="PerUserCacheKeyGeneratorTests.cs" />
     <Compile Include="DefaultCacheKeyGeneratorTests.cs" />
     <Compile Include="InlineInvalidateTests.cs">
       <SubType>Code</SubType>

--- a/test/WebApi.OutputCache.V2.Tests/WebApi.OutputCache.V2.Tests.csproj
+++ b/test/WebApi.OutputCache.V2.Tests/WebApi.OutputCache.V2.Tests.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="CacheKeyGeneratorRegistrationTests.cs" />
     <Compile Include="CacheKeyGeneratorTests.cs" />
+    <Compile Include="CacheKeyGenerationTestsBase.cs" />
     <Compile Include="ClientSideTests.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
This PR includes: 
* a small refactor on the `DefaultCacheKeyGenerator` to encapsulate some of the internal logic into protected methods for better extensibility
* a new `PerUserCacheKeyGenerator` that derives from the default one but includes user identity as one fragment of the key. This tackles request in #163. 
* Unit tests for both implementations of the `ICacheKeyGenerator`

The main driver is the second point, I believe is a very common scenario for any API that filters information based on user profile and better to provide it already in the package. Maybe we can also discuss other implementations to cover common scenarios similar to what's requested in #159.

Cheers!