### PR TITLE
Update IApiOutputCache to Async signatures

### DIFF
--- a/sample/WebApi.OutputCache.V2.Demo/TeamsController.cs
+++ b/sample/WebApi.OutputCache.V2.Demo/TeamsController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using System.Web.Http;
 using WebApi.OutputCache.V2.TimeAttributes;
 
@@ -37,7 +38,7 @@ namespace WebApi.OutputCache.V2.Demo
             Teams.Add(value);
         }
 
-        public void Put(int id, Team value)
+        public async Task Put(int id, Team value)
         {
             if (!ModelState.IsValid) throw new HttpResponseException(Request.CreateErrorResponse(HttpStatusCode.BadRequest, ModelState));
 
@@ -48,7 +49,7 @@ namespace WebApi.OutputCache.V2.Demo
             team.Name = value.Name;
 
             var cache = Configuration.CacheOutputConfiguration().GetCacheOutputProvider(Request);
-            cache.RemoveStartsWith(Configuration.CacheOutputConfiguration().MakeBaseCachekey((TeamsController t) => t.GetById(0)));
+            await cache.RemoveStartsWithAsync(Configuration.CacheOutputConfiguration().MakeBaseCachekey((TeamsController t) => t.GetById(0)));
         }
 
         public void Delete(int id)

--- a/src/WebApi.OutputCache.Core/Cache/CacheExtensions.cs
+++ b/src/WebApi.OutputCache.Core/Cache/CacheExtensions.cs
@@ -1,17 +1,18 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace WebApi.OutputCache.Core.Cache
 {
     public static class CacheExtensions
     {
-        public static T GetCachedResult<T>(this IApiOutputCache cache, string key, DateTimeOffset expiry, Func<T> resultGetter, bool bypassCache = true) where T : class
+        public static async Task<T> GetCachedResultAsync<T>(this IApiOutputCache cache, string key, DateTimeOffset expiry, Func<T> resultGetter, bool bypassCache = true) where T : class
         {
-            var result = cache.Get<T>(key);
+            var result = await cache.GetAsync<T>(key);
 
             if (result == null || bypassCache)
             {
                 result = resultGetter();
-                if (result != null) cache.Add(key, result, expiry);
+                if (result != null) await cache.AddAsync(key, result, expiry);
             }
 
             return result;

--- a/src/WebApi.OutputCache.Core/Cache/IApiOutputCache.cs
+++ b/src/WebApi.OutputCache.Core/Cache/IApiOutputCache.cs
@@ -1,23 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace WebApi.OutputCache.Core.Cache
 {
     public interface IApiOutputCache
     {
-        void RemoveStartsWith(string key);
+        Task RemoveStartsWithAsync(string key);
 
-        T Get<T>(string key) where T : class;
+        Task<T> GetAsync<T>(string key) where T : class;
 
-        [Obsolete("Use Get<T> instead")]
-        object Get(string key);
+        Task RemoveAsync(string key);
 
-        void Remove(string key);
+        Task<bool> ContainsAsync(string key);
 
-        bool Contains(string key);
+        Task AddAsync(string key, object value, DateTimeOffset expiration, string dependsOnKey = null);
 
-        void Add(string key, object o, DateTimeOffset expiration, string dependsOnKey = null);
-
-        IEnumerable<string> AllKeys { get; }
+        Task<IEnumerable<string>> AllKeysAsync { get; }
     }
 }

--- a/src/WebApi.OutputCache.Core/Cache/MemoryCacheDefault.cs
+++ b/src/WebApi.OutputCache.Core/Cache/MemoryCacheDefault.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Caching;
+using System.Threading.Tasks;
 
 namespace WebApi.OutputCache.Core.Cache
 {
@@ -9,7 +10,7 @@ namespace WebApi.OutputCache.Core.Cache
     {
         private static readonly MemoryCache Cache = MemoryCache.Default;
 
-        public virtual void RemoveStartsWith(string key)
+        private static void RemoveStartsWith(string key)
         {
             lock (Cache)
             {
@@ -17,19 +18,13 @@ namespace WebApi.OutputCache.Core.Cache
             }
         }
 
-        public virtual T Get<T>(string key) where T : class
+        private static T Get<T>(string key) where T : class
         {
             var o = Cache.Get(key) as T;
             return o;
         }
 
-        [Obsolete("Use Get<T> instead")]
-        public virtual object Get(string key)
-        {
-            return Cache.Get(key);
-        }
-
-        public virtual void Remove(string key)
+        private static void Remove(string key)
         {
             lock (Cache)
             {
@@ -37,12 +32,12 @@ namespace WebApi.OutputCache.Core.Cache
             }
         }
 
-        public virtual bool Contains(string key)
+        private static bool Contains(string key)
         {
             return Cache.Contains(key);
         }
 
-        public virtual void Add(string key, object o, DateTimeOffset expiration, string dependsOnKey = null)
+        private static void Add(string key, object o, DateTimeOffset expiration, string dependsOnKey = null)
         {
             var cachePolicy = new CacheItemPolicy
             {
@@ -59,14 +54,39 @@ namespace WebApi.OutputCache.Core.Cache
             {
                 Cache.Add(key, o, cachePolicy);
             }
-        }
+       }
 
-        public virtual IEnumerable<string> AllKeys
+        public virtual Task<IEnumerable<string>> AllKeysAsync
         {
             get
             {
-                return Cache.Select(x => x.Key);
+                return Task.FromResult(Cache.Select(x => x.Key));
             }
+        }
+
+        public virtual Task RemoveStartsWithAsync(string key)
+        {
+            return Task.Run(() => RemoveStartsWith(key));
+        }
+
+        public virtual Task<T> GetAsync<T>(string key) where T : class
+        {
+            return Task.FromResult(Get<T>(key));
+        }
+
+        public virtual Task RemoveAsync(string key)
+        {
+            return Task.Run(() => Remove(key));
+        }
+
+        public virtual Task<bool> ContainsAsync(string key)
+        {
+            return Task.FromResult(Contains(key));
+        }
+
+        public virtual Task AddAsync(string key, object value, DateTimeOffset expiration, string dependsOnKey = null)
+        {
+            return Task.Run(() => Add(key, value, expiration, dependsOnKey));
         }
     }
 }

--- a/src/WebApi.OutputCache.Core/Cache/MemoryCacheDefault.cs
+++ b/src/WebApi.OutputCache.Core/Cache/MemoryCacheDefault.cs
@@ -54,7 +54,7 @@ namespace WebApi.OutputCache.Core.Cache
             {
                 Cache.Add(key, o, cachePolicy);
             }
-       }
+        }
 
         public virtual Task<IEnumerable<string>> AllKeysAsync
         {
@@ -66,7 +66,8 @@ namespace WebApi.OutputCache.Core.Cache
 
         public virtual Task RemoveStartsWithAsync(string key)
         {
-            return Task.Run(() => RemoveStartsWith(key));
+            RemoveStartsWith(key);
+            return Task.FromResult(0);
         }
 
         public virtual Task<T> GetAsync<T>(string key) where T : class
@@ -76,7 +77,8 @@ namespace WebApi.OutputCache.Core.Cache
 
         public virtual Task RemoveAsync(string key)
         {
-            return Task.Run(() => Remove(key));
+            Remove(key);
+            return Task.FromResult(0);
         }
 
         public virtual Task<bool> ContainsAsync(string key)
@@ -86,7 +88,8 @@ namespace WebApi.OutputCache.Core.Cache
 
         public virtual Task AddAsync(string key, object value, DateTimeOffset expiration, string dependsOnKey = null)
         {
-            return Task.Run(() => Add(key, value, expiration, dependsOnKey));
+            Add(key, value, expiration, dependsOnKey);
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/WebApi.OutputCache.Core/WebApi.OutputCache.Core.csproj
+++ b/src/WebApi.OutputCache.Core/WebApi.OutputCache.Core.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WebApi.OutputCache.Core</RootNamespace>
     <AssemblyName>WebApi.OutputCache.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/WebApi.OutputCache.V2/AutoInvalidateCacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/AutoInvalidateCacheOutputAttribute.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;
@@ -15,7 +17,7 @@ namespace WebApi.OutputCache.V2
     {
         public bool TryMatchType { get; set; }
 
-        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        public override async Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
         {
             if (actionExecutedContext.Response != null && !actionExecutedContext.Response.IsSuccessStatusCode) return;
             if (actionExecutedContext.ActionContext.Request.Method != HttpMethod.Post &&
@@ -33,9 +35,9 @@ namespace WebApi.OutputCache.V2
             foreach (var action in actions)
             {
                 var key = config.CacheOutputConfiguration().MakeBaseCachekey(controller.ControllerType.FullName, action);
-                if (WebApiCache.Contains(key))
+                if (await WebApiCache.ContainsAsync(key))
                 {
-                    WebApiCache.RemoveStartsWith(key);
+                    await WebApiCache.RemoveStartsWithAsync(key);
                 }
             }
         }

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -274,7 +274,7 @@ namespace WebApi.OutputCache.V2
                                         cacheTime.AbsoluteExpiration, baseKey);
 
 
-                        _webApiCache.Add(cachekey + Constants.GenerationTimestampKey,
+                        await _webApiCache.AddAsync(cachekey + Constants.GenerationTimestampKey,
                                         actionExecutionTimestamp.ToString(),
                                         cacheTime.AbsoluteExpiration, baseKey);
                     }

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -166,7 +166,7 @@ namespace WebApi.OutputCache.V2
             return responseMediaType;
         }
 
-        public override void OnActionExecuting(HttpActionContext actionContext)
+        public override async Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
         {
             if (actionContext == null) throw new ArgumentNullException("actionContext");
 
@@ -183,11 +183,11 @@ namespace WebApi.OutputCache.V2
             actionContext.Request.Properties[CurrentRequestMediaType] = responseMediaType;
             var cachekey = cacheKeyGenerator.MakeCacheKey(actionContext, responseMediaType, ExcludeQueryStringFromCacheKey);
 
-            if (!_webApiCache.Contains(cachekey)) return;
+            if (await _webApiCache.ContainsAsync(cachekey) == false) return;
 
             if (actionContext.Request.Headers.IfNoneMatch != null)
             {
-                var etag = _webApiCache.Get<string>(cachekey + Constants.EtagKey);
+                var etag = await _webApiCache.GetAsync<string>(cachekey + Constants.EtagKey);
                 if (etag != null)
                 {
                     if (actionContext.Request.Headers.IfNoneMatch.Any(x => x.Tag ==  etag))
@@ -203,11 +203,11 @@ namespace WebApi.OutputCache.V2
                 }
             }
 
-            var val = _webApiCache.Get<byte[]>(cachekey);
+            var val = await _webApiCache.GetAsync<byte[]>(cachekey);
             if (val == null) return;
 
-            var contenttype = _webApiCache.Get<MediaTypeHeaderValue>(cachekey + Constants.ContentTypeKey) ?? responseMediaType;
-            var contentGeneration = _webApiCache.Get<string>(cachekey + Constants.GenerationTimestampKey);
+            var contenttype = await _webApiCache.GetAsync<MediaTypeHeaderValue>(cachekey + Constants.ContentTypeKey) ?? responseMediaType;
+            var contentGeneration = await _webApiCache.GetAsync<string>(cachekey + Constants.GenerationTimestampKey);
 
             DateTimeOffset? contentGenerationTimestamp = null;
             if (contentGeneration != null)
@@ -222,7 +222,7 @@ namespace WebApi.OutputCache.V2
             actionContext.Response.Content = new ByteArrayContent(val);
 
             actionContext.Response.Content.Headers.ContentType = contenttype;
-            var responseEtag = _webApiCache.Get<string>(cachekey + Constants.EtagKey);
+            var responseEtag = await _webApiCache.GetAsync<string>(cachekey + Constants.EtagKey);
             if (responseEtag != null) SetEtag(actionContext.Response,  responseEtag);
 
             var cacheTime = CacheTimeQuery.Execute(DateTime.Now);
@@ -246,7 +246,7 @@ namespace WebApi.OutputCache.V2
                 var responseMediaType = actionExecutedContext.Request.Properties[CurrentRequestMediaType] as MediaTypeHeaderValue ?? GetExpectedMediaType(httpConfig, actionExecutedContext.ActionContext);
                 var cachekey = cacheKeyGenerator.MakeCacheKey(actionExecutedContext.ActionContext, responseMediaType, ExcludeQueryStringFromCacheKey);
 
-                if (!string.IsNullOrWhiteSpace(cachekey) && !(_webApiCache.Contains(cachekey)))
+                if (!string.IsNullOrWhiteSpace(cachekey) && !(await _webApiCache.ContainsAsync(cachekey)))
                 {
                     SetEtag(actionExecutedContext.Response, CreateEtag(actionExecutedContext, cachekey, cacheTime));
 
@@ -262,16 +262,14 @@ namespace WebApi.OutputCache.V2
 
                         responseContent.Headers.Remove("Content-Length");
 
-                        _webApiCache.Add(baseKey, string.Empty, cacheTime.AbsoluteExpiration);
-                        _webApiCache.Add(cachekey, content, cacheTime.AbsoluteExpiration, baseKey);
-
+                        await _webApiCache.AddAsync(baseKey, string.Empty, cacheTime.AbsoluteExpiration);
+                        await _webApiCache.AddAsync(cachekey, content, cacheTime.AbsoluteExpiration, baseKey);
                        
-                        _webApiCache.Add(cachekey + Constants.ContentTypeKey,
+                        await _webApiCache.AddAsync(cachekey + Constants.ContentTypeKey,
                                         contentType,
                                         cacheTime.AbsoluteExpiration, baseKey);
-
-                       
-                        _webApiCache.Add(cachekey + Constants.EtagKey,
+                        
+                        await _webApiCache.AddAsync(cachekey + Constants.EtagKey,
                                         etag,
                                         cacheTime.AbsoluteExpiration, baseKey);
 

--- a/src/WebApi.OutputCache.V2/InvalidateCacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/InvalidateCacheOutputAttribute.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Http.Filters;
 
 namespace WebApi.OutputCache.V2
@@ -21,7 +23,7 @@ namespace WebApi.OutputCache.V2
             _methodName = methodName;
         }
 
-        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        public override async Task OnActionExecutedAsync(HttpActionExecutedContext actionExecutedContext, CancellationToken cancellationToken)
         {
             if (actionExecutedContext.Response != null && !actionExecutedContext.Response.IsSuccessStatusCode) return;
             _controller = _controller ?? actionExecutedContext.ActionContext.ControllerContext.ControllerDescriptor.ControllerType.FullName;
@@ -30,9 +32,9 @@ namespace WebApi.OutputCache.V2
             EnsureCache(config, actionExecutedContext.Request);
 
             var key = actionExecutedContext.Request.GetConfiguration().CacheOutputConfiguration().MakeBaseCachekey(_controller, _methodName);
-            if (WebApiCache.Contains(key))
+            if (await WebApiCache.ContainsAsync(key))
             {
-                WebApiCache.RemoveStartsWith(key);
+                await WebApiCache.RemoveStartsWithAsync(key);
             }
         }
     }

--- a/src/WebApi.OutputCache.V2/WebApi.OutputCache.V2.csproj
+++ b/src/WebApi.OutputCache.V2/WebApi.OutputCache.V2.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/test/WebApi.OutputCache.Core.Tests/MemoryCacheDefaultTests.cs
+++ b/test/WebApi.OutputCache.Core.Tests/MemoryCacheDefaultTests.cs
@@ -8,37 +8,37 @@ namespace WebApi.OutputCache.Core.Tests
     public class MemoryCacheDefaultTests
     {
         [Test]
-        public void returns_all_keys_in_cache()
+        public async void returns_all_keys_in_cache()
         {
             IApiOutputCache cache = new MemoryCacheDefault();
-            cache.Add("base", "abc", DateTime.Now.AddSeconds(60));
-            cache.Add("key1", "abc", DateTime.Now.AddSeconds(60), "base");
-            cache.Add("key2", "abc", DateTime.Now.AddSeconds(60), "base");
-            cache.Add("key3", "abc", DateTime.Now.AddSeconds(60), "base");
+            await cache.AddAsync("base", "abc" , DateTime.Now.AddSeconds(60));
+            await cache.AddAsync("key1", "abc", DateTime.Now.AddSeconds(60), "base");
+            await cache.AddAsync("key2", "abc", DateTime.Now.AddSeconds(60), "base");
+            await cache.AddAsync("key3", "abc", DateTime.Now.AddSeconds(60), "base");
 
-            var result = cache.AllKeys;
+            var result = await cache.AllKeysAsync;
 
             CollectionAssert.AreEquivalent(new[] { "base", "key1", "key2", "key3" }, result);
         }
 
         [Test]
-        public void remove_startswith_cascades_to_all_dependencies()
+        public async void remove_startswith_cascades_to_all_dependencies()
         {
             IApiOutputCache cache = new MemoryCacheDefault();
-            cache.Add("base", "abc", DateTime.Now.AddSeconds(60));
-            cache.Add("key1","abc", DateTime.Now.AddSeconds(60), "base");
-            cache.Add("key2", "abc", DateTime.Now.AddSeconds(60), "base");
-            cache.Add("key3", "abc", DateTime.Now.AddSeconds(60), "base");
-            Assert.IsNotNull(cache.Get("key1"));
-            Assert.IsNotNull(cache.Get("key2"));
-            Assert.IsNotNull(cache.Get("key3"));
+            await cache.AddAsync("base", "abc", DateTime.Now.AddSeconds(60));
+            await cache.AddAsync("key1","abc", DateTime.Now.AddSeconds(60), "base");
+            await cache.AddAsync("key2", "abc", DateTime.Now.AddSeconds(60), "base");
+            await cache.AddAsync("key3", "abc", DateTime.Now.AddSeconds(60), "base");
+            Assert.IsNotNull(cache.GetAsync<string>("key1"));
+            Assert.IsNotNull(cache.GetAsync<string>("key2"));
+            Assert.IsNotNull(cache.GetAsync<string>("key3"));
 
-            cache.RemoveStartsWith("base");
+            await cache.RemoveStartsWithAsync("base");
 
-            Assert.IsNull(cache.Get("base"));
-            Assert.IsNull(cache.Get("key1"));
-            Assert.IsNull(cache.Get("key2"));
-            Assert.IsNull(cache.Get("key3"));
+            Assert.IsNull(cache.GetAsync<string>("base").Result);
+            Assert.IsNull(cache.GetAsync<string>("key1").Result);
+            Assert.IsNull(cache.GetAsync<string>("key2").Result);
+            Assert.IsNull(cache.GetAsync<string>("key3").Result);
         }
     }
 }

--- a/test/WebApi.OutputCache.V2.Tests/CacheKeyGeneratorRegistrationTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/CacheKeyGeneratorRegistrationTests.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using Autofac;
@@ -26,6 +27,8 @@ namespace WebApi.OutputCache.V2.Tests
             Thread.CurrentPrincipal = null;
 
             _cache = new Mock<IApiOutputCache>();
+            _cache.Setup(cache => cache.ContainsAsync(It.IsAny<string>())).Returns(Task.FromResult(It.IsAny<bool>()));
+            _cache.Setup(cache => cache.AddAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>())).Returns(Task.FromResult(default(object)));
             _keyGenerator = new Mock<ICacheKeyGenerator>();
 
             var conf = new HttpConfiguration();
@@ -89,7 +92,7 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.GetAsync(_url + "cachekey/get_internalregistered").Result;
 
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "internal"), It.IsAny<byte[]>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.cachekeycontroller-get_internalregistered")), Times.Once());
+            _cache.Verify(s => s.AddAsync(It.Is<string>(x => x == "internal"), It.IsAny<byte[]>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.cachekeycontroller-get_internalregistered")), Times.Once());
         }
 
         [Test]
@@ -98,7 +101,7 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.GetAsync(_url + "cachekey/get_unregistered").Result;
 
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "unregistered")), Times.Once());
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "unregistered")), Times.Once());
         }
 
         #region Helper classes

--- a/test/WebApi.OutputCache.V2.Tests/ConfigurationTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ConfigurationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 using System.Web.Http;
 using Moq;
 using NUnit.Framework;
@@ -18,6 +19,7 @@ namespace WebApi.OutputCache.V2.Tests
         public void cache_singleton_in_pipeline()
         {
             _cache = new Mock<IApiOutputCache>();
+            _cache.Setup(cache => cache.ContainsAsync(It.IsAny<string>())).Returns(Task.FromResult(It.IsAny<bool>()));
 
             var conf = new HttpConfiguration();
             conf.CacheOutputConfiguration().RegisterCacheOutputProvider(() => _cache.Object);
@@ -33,10 +35,10 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.GetAsync(_url + "Get_c100_s100").Result;
 
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8")), Times.Exactly(2));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8")), Times.Exactly(2));
 
             var result2 = client.GetAsync(_url + "Get_c100_s100").Result;
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8")), Times.Exactly(4));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8")), Times.Exactly(4));
 
             _server.Dispose();
         }

--- a/test/WebApi.OutputCache.V2.Tests/ConnegTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ConnegTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using System.Web.Http;
 using Autofac;
 using Autofac.Integration.WebApi;
@@ -21,6 +22,8 @@ namespace WebApi.OutputCache.V2.Tests
         public void init()
         {
             _cache = new Mock<IApiOutputCache>();
+            _cache.Setup(cache => cache.ContainsAsync(It.IsAny<string>())).Returns(Task.FromResult(It.IsAny<bool>()));
+            _cache.Setup(cache => cache.AddAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<DateTimeOffset>(), It.IsAny<string>())).Returns(Task.FromResult(default(object)));
 
             var conf = new HttpConfiguration();
             var builder = new ContainerBuilder();
@@ -42,15 +45,15 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.GetAsync(_url + "Get_c100_s100").Result;
 
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Once());
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8")), Times.Exactly(2));
+            _cache.Verify(s => s.AddAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Once());
 
             var req = new HttpRequestMessage(HttpMethod.Get, _url + "Get_c100_s100");
             req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/xml"));
 
             var result2 = client.SendAsync(req).Result;
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:text/xml; charset=utf-8")), Times.Exactly(2));
-            _cache.Verify(s => s.Add(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:text/xml; charset=utf-8"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Once());
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:text/xml; charset=utf-8")), Times.Exactly(2));
+            _cache.Verify(s => s.AddAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:text/xml; charset=utf-8"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Once());
 
         }
             

--- a/test/WebApi.OutputCache.V2.Tests/InlineInvalidateTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/InlineInvalidateTests.cs
@@ -44,7 +44,7 @@ namespace WebApi.OutputCache.V2.Tests
 
             var result = client.PostAsync(_url + "Post", new StringContent(string.Empty)).Result;
 
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.inlineinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.inlineinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
         }
 
         [Test]
@@ -53,7 +53,7 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.PutAsync(_url + "Put", new StringContent(string.Empty)).Result;
 
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.inlineinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.inlineinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.DeleteAsync(_url + "Delete_parameterized").Result;
 
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.inlineinvalidatecontroller-get_c100_s100_with_param")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.inlineinvalidatecontroller-get_c100_s100_with_param")), Times.Exactly(1));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace WebApi.OutputCache.V2.Tests
             var client = new HttpClient(_server);
             var result = client.DeleteAsync(_url + "Delete_non_standard_name").Result;
 
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.inlineinvalidatecontroller-getbyid")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.inlineinvalidatecontroller-getbyid")), Times.Exactly(1));
         }
 
         [TearDown]

--- a/test/WebApi.OutputCache.V2.Tests/InvalidateTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/InvalidateTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Http;
 using Autofac;
 using Autofac.Integration.WebApi;
@@ -23,6 +25,8 @@ namespace WebApi.OutputCache.V2.Tests
             Thread.CurrentPrincipal = null;
 
             _cache = new Mock<IApiOutputCache>();
+            _cache.Setup(cache => cache.ContainsAsync(It.IsAny<string>())).Returns(Task.FromResult(It.IsAny<bool>()));
+            _cache.Setup(cache => cache.RemoveStartsWithAsync(It.IsAny<string>())).Returns(Task.FromResult(default(object)));
 
             var conf = new HttpConfiguration();
             var builder = new ContainerBuilder();
@@ -46,8 +50,8 @@ namespace WebApi.OutputCache.V2.Tests
 
             var result2 = client.PostAsync(_url + "Post", new StringContent(string.Empty)).Result;
 
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Exactly(1));
         }
 
         [Test]
@@ -58,10 +62,10 @@ namespace WebApi.OutputCache.V2.Tests
 
             var result2 = client.PostAsync(_url + "Post_2_invalidates", new StringContent(string.Empty)).Result;
 
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
         }
 
         [Test]
@@ -72,12 +76,12 @@ namespace WebApi.OutputCache.V2.Tests
 
             var result2 = client.PostAsync("http://www.strathweb.com/api/autoinvalidate/Post", new StringContent(string.Empty)).Result;
 
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
         }
 
         [Test]
@@ -88,12 +92,12 @@ namespace WebApi.OutputCache.V2.Tests
 
             var result2 = client.PutAsync("http://www.strathweb.com/api/autoinvalidate/Put", new StringContent(string.Empty)).Result;
 
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
         }
 
         [Test]
@@ -104,12 +108,12 @@ namespace WebApi.OutputCache.V2.Tests
 
             var result2 = client.DeleteAsync("http://www.strathweb.com/api/autoinvalidate/Delete").Result;
             
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304")), Times.Exactly(1));
         }
 
         [Test]
@@ -121,8 +125,8 @@ namespace WebApi.OutputCache.V2.Tests
             var result2 = client.PostAsync("http://www.strathweb.com/api/autoinvalidatewithtype/Post", new StringContent(string.Empty)).Result;
             
             Assert.True(result2.IsSuccessStatusCode);
-            _cache.Verify(s => s.Contains(It.IsAny<string>()), Times.Never());
-            _cache.Verify(s => s.RemoveStartsWith(It.IsAny<string>()), Times.Never());
+            _cache.Verify(s => s.ContainsAsync(It.IsAny<string>()), Times.Never());
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.IsAny<string>()), Times.Never());
         }
 
         [Test]
@@ -133,24 +137,24 @@ namespace WebApi.OutputCache.V2.Tests
 
             var result2 = client.PostAsync("http://www.strathweb.com/api/autoinvalidatewithtype/PostString", "hi", new JsonMediaTypeFormatter()).Result;
 
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100_array")), Times.Exactly(1));
-            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_s50_exclude_fakecallback")), Times.Never());
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100_array")), Times.Exactly(1));
-            _cache.Verify(s => s.RemoveStartsWith(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_s50_exclude_fakecallback")), Times.Never());
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100_array")), Times.Exactly(1));
+            _cache.Verify(s => s.ContainsAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_s50_exclude_fakecallback")), Times.Never());
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100_array")), Times.Exactly(1));
+            _cache.Verify(s => s.RemoveStartsWithAsync(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_s50_exclude_fakecallback")), Times.Never());
         }
 
         private void SetupCacheForAutoInvalidate()
         {            
-            _cache.Setup(x => x.Contains(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_s50_exclude_fakecallback"))).Returns(true);
-            _cache.Setup(x => x.Contains(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100"))).Returns(true);
-            _cache.Setup(x => x.Contains(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100"))).Returns(true);
-            _cache.Setup(x => x.Contains(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback"))).Returns(true);
-            _cache.Setup(x => x.Contains(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304"))).Returns(true);
-            _cache.Setup(x => x.Contains(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100"))).Returns(true);
-            _cache.Setup(x => x.Contains(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_s50_exclude_fakecallback"))).Returns(true);
-            _cache.Setup(x => x.Contains(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100_array"))).Returns(true);   
+            _cache.Setup(x => x.ContainsAsync(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_s50_exclude_fakecallback"))).Returns(Task.FromResult(true));
+            _cache.Setup(x => x.ContainsAsync(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100"))).Returns(Task.FromResult(true));
+            _cache.Setup(x => x.ContainsAsync(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_c100_s100"))).Returns(Task.FromResult(true));
+            _cache.Setup(x => x.ContainsAsync(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-get_s50_exclude_fakecallback"))).Returns(Task.FromResult(true));
+            _cache.Setup(x => x.ContainsAsync(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatecontroller-etag_match_304"))).Returns(Task.FromResult(true));
+            _cache.Setup(x => x.ContainsAsync(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100"))).Returns(Task.FromResult(true));
+            _cache.Setup(x => x.ContainsAsync(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_s50_exclude_fakecallback"))).Returns(Task.FromResult(true));
+            _cache.Setup(x => x.ContainsAsync(It.Is<string>(s => s == "webapi.outputcache.v2.tests.testcontrollers.autoinvalidatewithtypecontroller-get_c100_s100_array"))).Returns(Task.FromResult(true));   
         }
    
         [TearDown]

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/InlineInvalidateController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/InlineInvalidateController.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http;
+﻿using System.Threading.Tasks;
+using System.Web.Http;
 
 namespace WebApi.OutputCache.V2.Tests.TestControllers
 {
@@ -36,32 +37,32 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
             return "value";
         }
 
-        public void Post()
+        public async Task Post()
         {
             var cache = Configuration.CacheOutputConfiguration().GetCacheOutputProvider(Request);
-            cache.RemoveStartsWith(Configuration.CacheOutputConfiguration().MakeBaseCachekey(this.GetType().FullName, "Get_c100_s100"));
+            await cache.RemoveStartsWithAsync(Configuration.CacheOutputConfiguration().MakeBaseCachekey(this.GetType().FullName, "Get_c100_s100"));
 
             //do nothing
         }
 
-        public void Put()
+        public async Task Put()
         {
             var cache = Configuration.CacheOutputConfiguration().GetCacheOutputProvider(Request);
-            cache.RemoveStartsWith(Configuration.CacheOutputConfiguration().MakeBaseCachekey((InlineInvalidateController x) => x.Get_c100_s100()));
+            await cache.RemoveStartsWithAsync(Configuration.CacheOutputConfiguration().MakeBaseCachekey((InlineInvalidateController x) => x.Get_c100_s100()));
 
             //do nothing
         }
 
-        public void Delete_non_standard_name()
+        public async Task Delete_non_standard_name()
         {
             var cache = Configuration.CacheOutputConfiguration().GetCacheOutputProvider(Request);
-            cache.RemoveStartsWith(Configuration.CacheOutputConfiguration().MakeBaseCachekey((InlineInvalidateController x) => x.Get_c100_s100(7)));            
+            await cache.RemoveStartsWithAsync(Configuration.CacheOutputConfiguration().MakeBaseCachekey((InlineInvalidateController x) => x.Get_c100_s100(7)));            
         }
 
-        public void Delete_parameterized()
+        public async Task Delete_parameterized()
         {
             var cache = Configuration.CacheOutputConfiguration().GetCacheOutputProvider(Request);
-            cache.RemoveStartsWith(Configuration.CacheOutputConfiguration().MakeBaseCachekey((InlineInvalidateController x) => x.Get_c100_s100_with_param(7)));
+            await cache.RemoveStartsWithAsync(Configuration.CacheOutputConfiguration().MakeBaseCachekey((InlineInvalidateController x) => x.Get_c100_s100_with_param(7)));
 
             //do nothing
         }


### PR DESCRIPTION
Removes obsolete Get signature.
Updates Core library to Framework 4.5 to better facilitate Task methods.
IApiOutputCache usages and implementations are adjusted to use the updated interface.

This relates to the request to update the interface to have async signatures #158 

I hope this is the approach you were aiming at.