### PR TITLE
Excluding action arguments with [FromUri] attribute from cache key

### DIFF
--- a/src/WebApi.OutputCache.V2/DefaultCacheKeyGenerator.cs
+++ b/src/WebApi.OutputCache.V2/DefaultCacheKeyGenerator.cs
@@ -26,7 +26,10 @@ namespace WebApi.OutputCache.V2
 
         protected virtual string FormatParameters(HttpActionContext context, bool excludeQueryString)
         {
-            var actionParameters = context.ActionArguments.Where(x => x.Value != null).Select(x => x.Key + "=" + GetValue(x.Value));
+            var actionParameters = context
+                .ActionArguments
+                .Where(x => x.Value != null && (x.Value is string || x.Value.GetType().IsValueType))
+                .Select(x => x.Key + "=" + GetValue(x.Value));
 
             string parameters;
 

--- a/test/WebApi.OutputCache.V2.Tests/CacheKeyGenerationTestsBase.cs
+++ b/test/WebApi.OutputCache.V2.Tests/CacheKeyGenerationTestsBase.cs
@@ -10,13 +10,22 @@ namespace WebApi.OutputCache.V2.Tests
     /// </summary>
     public abstract class CacheKeyGenerationTestsBase<TCacheKeyGenerator> where TCacheKeyGenerator : ICacheKeyGenerator
     {
-        private const string ArgumentKey = "filterExpression";
-        private const string ArgumentValue = "val";
+        private const string Argument1Key = "filterExpression1";
+        private const string Argument1Value = "val";
+        private const string Argument2WithFromUriAttributeKey = "filterExpression2";
+        private static readonly ClassArgument Argument2WithFromUriAttributeValue = new ClassArgument() { Value1 = "val1", Value2 = 7 };
         protected HttpActionContext context;
         protected MediaTypeHeaderValue mediaType;
         protected Uri requestUri;
         protected TCacheKeyGenerator cacheKeyGenerator;
         protected string BaseCacheKey;
+
+        private class ClassArgument
+        {
+            public string Value1 { get; set; }
+
+            public int Value2 { get; set; }
+        }
 
         [SetUp]
         public virtual void Setup()
@@ -49,12 +58,13 @@ namespace WebApi.OutputCache.V2.Tests
 
         protected void AddActionArgumentsToContext()
         {
-            context.ActionArguments.Add(ArgumentKey, ArgumentValue);
+            context.ActionArguments.Add(Argument1Key, Argument1Value);
+            context.ActionArguments.Add(Argument2WithFromUriAttributeKey, Argument2WithFromUriAttributeValue);
         }
 
         protected string FormatActionArgumentsForKeyAssertion()
         {
-            return String.Format("{0}={1}", ArgumentKey, ArgumentValue);
+            return String.Format("{0}={1}", Argument1Key, Argument1Value);
         }
     }
 }


### PR DESCRIPTION
**Scenario:** One of action arguments is a class attributed with [FromUri].

```java
[HttpGet]
[Route(@"api/v{version:apiVersion}/users")]
public async Task<IHttpActionResult> GetUsers([FromUri]SearchUsersRequestDto searchRequest)
{
    ...        
}
```

**As a result the following key generated:**

> userservice.web.api.v1.m0.controllers.usercontroller-getusers-**searchRequest=UserService.Web.Api.V1.M0.Models.SearchUsersRequestDto**&skip=0&take=10:application/json; charset=utf-8

**Expected result:**

> userservice.web.api.v1.m0.controllers.usercontroller-getusers-skip=0&take=10:application/json; charset=utf-8