### PR TITLE
Set ETag when returning a 304 response code

### DIFF
--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -194,6 +194,8 @@ namespace WebApi.OutputCache.V2
                     {
                         var time = CacheTimeQuery.Execute(DateTime.Now);
                         var quickResponse = actionContext.Request.CreateResponse(HttpStatusCode.NotModified);
+                        
+                        SetEtag(quickResponse, etag);
                         ApplyCacheHeaders(quickResponse, time);
                         actionContext.Response = quickResponse;
                         return;


### PR DESCRIPTION
According to the [ RFC 7232 ](https://tools.ietf.org/html/rfc7232#section-4.1), the ETag header should be returned when the cache send back a 304 Not Modified status code:

> The server generating a 304 response MUST generate any of the following header fields that would have been sent in a 200 (OK) response to the same request: Cache-Control, Content-Location, Date, ETag, Expires, and Vary.

This change adds just that.
