### PR TITLE
Ability to cache specified HTTP headers. (v2)

### DIFF
--- a/src/WebApi.OutputCache.Core/Constants.cs
+++ b/src/WebApi.OutputCache.Core/Constants.cs
@@ -5,5 +5,7 @@
         public const string ContentTypeKey = ":response-ct";
         public const string EtagKey = ":response-etag";
         public const string GenerationTimestampKey = ":response-generationtimestamp";
+        public const string CustomHeaders = ":custom-headers";
+        public const string CustomContentHeaders = ":custom-content-headers";
     }
 }

--- a/test/WebApi.OutputCache.Core.Tests/WebApi.OutputCache.Core.Tests.csproj
+++ b/test/WebApi.OutputCache.Core.Tests/WebApi.OutputCache.Core.Tests.csproj
@@ -56,6 +56,9 @@
       <Name>WebApi.OutputCache.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/WebApi.OutputCache.V2.Tests/ClientSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ClientSideTests.cs
@@ -122,8 +122,8 @@ namespace WebApi.OutputCache.V2.Tests
         public void maxage_mustrevalidate_headers_correct_with_cacheuntil()
         {
             var client = new HttpClient(_server);
-            var result = client.GetAsync(_url + "Get_until25012015_1700").Result;
-            var clientTimeSpanSeconds = new SpecificTime(2019, 01, 25, 17, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds;
+            var result = client.GetAsync(_url + "Get_until25012100_1700").Result;
+            var clientTimeSpanSeconds = new SpecificTime(2100, 01, 25, 17, 0, 0).Execute(DateTime.Now).ClientTimeSpan.TotalSeconds;
             var resultCacheControlSeconds = ((TimeSpan) result.Headers.CacheControl.MaxAge).TotalSeconds;
             Assert.IsTrue(Math.Round(clientTimeSpanSeconds - resultCacheControlSeconds) == 0);
             Assert.IsFalse(result.Headers.CacheControl.MustRevalidate);

--- a/test/WebApi.OutputCache.V2.Tests/CustomHeadersContent.cs
+++ b/test/WebApi.OutputCache.V2.Tests/CustomHeadersContent.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Results;
+
+namespace WebApi.OutputCache.V2.Tests
+{
+    public class CustomHeadersContent<T> : OkNegotiatedContentResult<T>
+    {
+        public string ContentDisposition { get; set; }
+
+        public List<string> ContentEncoding { get; set; }
+
+        public string RequestHeader1 { get; set; }
+
+        public List<string> RequestHeader2 { get; set; }
+
+        public CustomHeadersContent(T content, ApiController controller)
+            : base(content, controller) { }
+
+        public CustomHeadersContent(T content, IContentNegotiator contentNegotiator, HttpRequestMessage request, IEnumerable<MediaTypeFormatter> formatters)
+            : base(content, contentNegotiator, request, formatters) { }
+
+        public override async Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = await base.ExecuteAsync(cancellationToken);
+
+            if (!string.IsNullOrWhiteSpace(ContentDisposition))
+            {
+                response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue(ContentDisposition);
+            }
+            if (ContentEncoding != null)
+            {
+                foreach (var contentEncoding in ContentEncoding)
+                {
+                    response.Content.Headers.ContentEncoding.Add(contentEncoding);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(RequestHeader1))
+            {
+                response.Headers.Add("RequestHeader1", RequestHeader1);
+            }
+            if (RequestHeader2 != null)
+            {
+                foreach (var requestHeader2Value in RequestHeader2)
+                {
+                    response.Headers.Add("RequestHeader2", requestHeader2Value);
+                }
+            }
+
+            return response;
+        }
+    }
+}

--- a/test/WebApi.OutputCache.V2.Tests/CustomHeadersTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/CustomHeadersTests.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Principal;
+using System.Threading;
+using System.Web.Http;
+using Autofac;
+using Autofac.Integration.WebApi;
+using Moq;
+using NUnit.Framework;
+using WebApi.OutputCache.Core;
+using WebApi.OutputCache.Core.Cache;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WebApi.OutputCache.V2.Tests
+{
+    [TestFixture]
+    public class CustomHeadersTests
+    {
+        private HttpServer _server;
+        private string _url = "http://www.strathweb.com/api/customheaders/";
+        private IApiOutputCache _cache;
+
+        [SetUp]
+        public void init()
+        {
+            Thread.CurrentPrincipal = null;
+
+            _cache = new SimpleCacheForTests();
+
+            var conf = new HttpConfiguration();
+            var builder = new ContainerBuilder();
+            builder.RegisterInstance(_cache);
+
+            conf.DependencyResolver = new AutofacWebApiDependencyResolver(builder.Build());
+            conf.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{action}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+                );
+
+            _server = new HttpServer(conf);
+        }
+
+        [Test]
+        public void cache_custom_content_header() {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Custom_Content_Header");
+            var result = client.SendAsync(req).Result;
+
+            var req2 = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Custom_Content_Header");
+            var result2 = client.SendAsync(req2).Result;
+
+            Assert.That(result.Content.Headers.ContentDisposition.DispositionType, Is.EqualTo("attachment"));
+            Assert.That(result2.Content.Headers.ContentDisposition.DispositionType, Is.EqualTo("attachment"));
+        }
+
+        [Test]
+        public void cache_custom_content_header_with_multiply_values()
+        {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Custom_Content_Header_Multiply_Values");
+            var result = client.SendAsync(req).Result;
+
+            var req2 = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Custom_Content_Header_Multiply_Values");
+            var result2 = client.SendAsync(req2).Result;
+
+            Assert.That(result.Content.Headers.ContentEncoding.Count, Is.EqualTo(2));
+            Assert.That(result.Content.Headers.ContentEncoding.First(), Is.EqualTo("deflate"));
+            Assert.That(result.Content.Headers.ContentEncoding.Last(), Is.EqualTo("gzip"));
+
+            Assert.That(result2.Content.Headers.ContentEncoding.Count, Is.EqualTo(2));
+            Assert.That(result2.Content.Headers.ContentEncoding.First(), Is.EqualTo("deflate"));
+            Assert.That(result2.Content.Headers.ContentEncoding.Last(), Is.EqualTo("gzip"));
+        }
+
+        [Test]
+        public void cache_custom_response_header()
+        {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Custom_Response_Header");
+            var result = client.SendAsync(req).Result;
+
+            var req2 = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Custom_Response_Header");
+            var result2 = client.SendAsync(req2).Result;
+
+            Assert.That(result.Headers.GetValues("RequestHeader1").First(), Is.EqualTo("value1"));
+            Assert.That(result2.Headers.GetValues("RequestHeader1").First(), Is.EqualTo("value1"));
+        }
+
+        [Test]
+        public void cache_custom_response_header_with_multiply_values()
+        {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Custom_Response_Header_Multiply_Values");
+            var result = client.SendAsync(req).Result;
+
+            var req2 = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Custom_Response_Header_Multiply_Values");
+            var result2 = client.SendAsync(req2).Result;
+
+            Assert.That(result.Headers.GetValues("RequestHeader2").Count(), Is.EqualTo(2));
+            Assert.That(result.Headers.GetValues("RequestHeader2").First(), Is.EqualTo("value2"));
+            Assert.That(result.Headers.GetValues("RequestHeader2").Last(), Is.EqualTo("value3"));
+
+            Assert.That(result2.Headers.GetValues("RequestHeader2").Count(), Is.EqualTo(2));
+            Assert.That(result2.Headers.GetValues("RequestHeader2").First(), Is.EqualTo("value2"));
+            Assert.That(result2.Headers.GetValues("RequestHeader2").Last(), Is.EqualTo("value3"));
+        }
+
+        [Test]
+        public void cache_multiply_custom_headers()
+        {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Multiply_Custom_Headers");
+            var result = client.SendAsync(req).Result;
+
+            var req2 = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Multiply_Custom_Headers");
+            var result2 = client.SendAsync(req2).Result;
+
+            Assert.That(result.Content.Headers.ContentDisposition.DispositionType, Is.EqualTo("attachment"));
+            Assert.That(result.Content.Headers.ContentEncoding.Count, Is.EqualTo(2));
+            Assert.That(result.Content.Headers.ContentEncoding.First(), Is.EqualTo("deflate"));
+            Assert.That(result.Content.Headers.ContentEncoding.Last(), Is.EqualTo("gzip"));
+            Assert.That(result.Headers.GetValues("RequestHeader1").First(), Is.EqualTo("value1"));
+            Assert.That(result.Headers.GetValues("RequestHeader2").Count(), Is.EqualTo(2));
+            Assert.That(result.Headers.GetValues("RequestHeader2").First(), Is.EqualTo("value2"));
+            Assert.That(result.Headers.GetValues("RequestHeader2").Last(), Is.EqualTo("value3"));
+
+            Assert.That(result2.Content.Headers.ContentDisposition.DispositionType, Is.EqualTo("attachment"));
+            Assert.That(result2.Content.Headers.ContentEncoding.Count, Is.EqualTo(2));
+            Assert.That(result2.Content.Headers.ContentEncoding.First(), Is.EqualTo("deflate"));
+            Assert.That(result2.Content.Headers.ContentEncoding.Last(), Is.EqualTo("gzip"));
+            Assert.That(result2.Headers.GetValues("RequestHeader1").First(), Is.EqualTo("value1"));
+            Assert.That(result2.Headers.GetValues("RequestHeader2").Count(), Is.EqualTo(2));
+            Assert.That(result2.Headers.GetValues("RequestHeader2").First(), Is.EqualTo("value2"));
+            Assert.That(result2.Headers.GetValues("RequestHeader2").Last(), Is.EqualTo("value3"));
+        }
+
+        [Test]
+        public void cache_part_of_custom_headers()
+        {
+            var client = new HttpClient(_server);
+            var req = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Part_Of_Custom_Headers");
+            var result = client.SendAsync(req).Result;
+
+            var req2 = new HttpRequestMessage(HttpMethod.Get, _url + "Cache_Part_Of_Custom_Headers");
+            var result2 = client.SendAsync(req2).Result;
+
+            Assert.That(result.Content.Headers.ContentDisposition.DispositionType, Is.EqualTo("attachment"));
+            Assert.That(result.Content.Headers.ContentEncoding.Count, Is.EqualTo(2));
+            Assert.That(result.Content.Headers.ContentEncoding.First(), Is.EqualTo("deflate"));
+            Assert.That(result.Content.Headers.ContentEncoding.Last(), Is.EqualTo("gzip"));
+            Assert.That(result.Headers.GetValues("RequestHeader1").First(), Is.EqualTo("value1"));
+            Assert.That(result.Headers.GetValues("RequestHeader2").Count(), Is.EqualTo(2));
+            Assert.That(result.Headers.GetValues("RequestHeader2").First(), Is.EqualTo("value2"));
+            Assert.That(result.Headers.GetValues("RequestHeader2").Last(), Is.EqualTo("value3"));
+
+            Assert.That(result2.Content.Headers.ContentDisposition, Is.Null);
+            Assert.That(result2.Content.Headers.ContentEncoding.Count, Is.EqualTo(2));
+            Assert.That(result2.Content.Headers.ContentEncoding.First(), Is.EqualTo("deflate"));
+            Assert.That(result2.Content.Headers.ContentEncoding.Last(), Is.EqualTo("gzip"));
+
+            IEnumerable<string> headerValue = null;
+            Assert.That(result2.Headers.TryGetValues("RequestHeader1", out headerValue), Is.False);
+            Assert.That(result2.Headers.TryGetValues("RequestHeader2", out headerValue), Is.False);
+        }
+
+        [TearDown]
+        public void fixture_dispose()
+        {
+            if (_server != null) _server.Dispose();
+        }
+    }
+}

--- a/test/WebApi.OutputCache.V2.Tests/MemoryCacheForTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/MemoryCacheForTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WebApi.OutputCache.Core.Cache;
+
+namespace WebApi.OutputCache.V2.Tests
+{
+    public class SimpleCacheForTests : IApiOutputCache
+    {
+        private Dictionary<string, object> _cachedItems;
+
+        public SimpleCacheForTests() {
+            _cachedItems = new Dictionary<string, object>();
+        }
+
+        public virtual void RemoveStartsWith(string key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual T Get<T>(string key) where T : class
+        {
+            var o = _cachedItems[key] as T;
+            return o;
+        }
+
+        [Obsolete("Use Get<T> instead")]
+        public virtual object Get(string key)
+        {
+            return _cachedItems[key];
+        }
+
+        public virtual void Remove(string key)
+        {
+            _cachedItems.Remove(key);
+        }
+
+        public virtual bool Contains(string key)
+        {
+            return _cachedItems.ContainsKey(key);
+        }
+
+        public virtual void Add(string key, object o, DateTimeOffset expiration, string dependsOnKey = null)
+        {
+            _cachedItems.Add(key, o);
+        }
+
+        public virtual IEnumerable<string> AllKeys
+        {
+            get
+            {
+                return _cachedItems.Keys;
+            }
+        }
+    }
+}

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/CustomHeadersController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/CustomHeadersController.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace WebApi.OutputCache.V2.Tests.TestControllers
+{
+    public class CustomHeadersController : ApiController
+    {
+        [HttpGet]
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100, IncludeCustomHeaders = "Content-Disposition")]
+        public IHttpActionResult Cache_Custom_Content_Header()
+        {
+            var result = new CustomHeadersContent<string>("test", this)
+            {
+                ContentDisposition = "attachment"
+            };
+
+            return result;
+        }
+
+        [HttpGet]
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100, IncludeCustomHeaders = "Content-Encoding")]
+        public IHttpActionResult Cache_Custom_Content_Header_Multiply_Values()
+        {
+            var result = new CustomHeadersContent<string>("test", this)
+            {
+                ContentEncoding = new List<string> { "deflate", "gzip" }
+            };
+
+            return result;
+        }
+
+        [HttpGet]
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100, IncludeCustomHeaders = "RequestHeader1")]
+        public IHttpActionResult Cache_Custom_Response_Header()
+        {
+            var result = new CustomHeadersContent<string>("test", this)
+            {
+                RequestHeader1 = "value1"
+            };
+
+            return result;
+        }
+
+        [HttpGet]
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100, IncludeCustomHeaders = "RequestHeader2")]
+        public IHttpActionResult Cache_Custom_Response_Header_Multiply_Values()
+        {
+            var result = new CustomHeadersContent<string>("test", this)
+            {
+                RequestHeader2 = new List<string> { "value2", "value3" }
+            };
+
+            return result;
+        }
+
+        [HttpGet]
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100, IncludeCustomHeaders = "Content-Disposition,Content-Encoding,RequestHeader2,RequestHeader1")]
+        public IHttpActionResult Cache_Multiply_Custom_Headers()
+        {
+            var result = new CustomHeadersContent<string>("test", this)
+            {
+                ContentDisposition = "attachment",
+                ContentEncoding = new List<string> { "deflate", "gzip" },
+                RequestHeader1 = "value1",
+                RequestHeader2 = new List<string> { "value2", "value3" }
+            };
+
+            return result;
+        }
+
+        [HttpGet]
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100, IncludeCustomHeaders = "Content-Encoding")]
+        public IHttpActionResult Cache_Part_Of_Custom_Headers()
+        {
+            var result = new CustomHeadersContent<string>("test", this)
+            {
+                ContentDisposition = "attachment",
+                ContentEncoding = new List<string> { "deflate", "gzip" },
+                RequestHeader1 = "value1",
+                RequestHeader2 = new List<string> { "value2", "value3" }
+            };
+
+            return result;
+        }
+    }
+}

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/CustomHeadersController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/CustomHeadersController.cs
@@ -73,7 +73,7 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
         }
 
         [HttpGet]
-        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100, IncludeCustomHeaders = "Content-Encoding")]
+        [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 100, IncludeCustomHeaders = "Content-Encoding,NotExistingHeader")]
         public IHttpActionResult Cache_Part_Of_Custom_Headers()
         {
             var result = new CustomHeadersContent<string>("test", this)

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Web.Http;
@@ -74,8 +75,8 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
             return "test" + id;
         }
 
-        [CacheOutputUntil(2019,01,25,17,00)]
-        public string Get_until25012015_1700()
+        [CacheOutputUntil(2100, 01,25,17,00)]
+        public string Get_until25012100_1700()
         {
             return "test";
         }

--- a/test/WebApi.OutputCache.V2.Tests/WebApi.OutputCache.V2.Tests.csproj
+++ b/test/WebApi.OutputCache.V2.Tests/WebApi.OutputCache.V2.Tests.csproj
@@ -84,6 +84,8 @@
     <Compile Include="ConnegTests.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="CustomHeadersContent.cs" />
+    <Compile Include="MemoryCacheForTests.cs" />
     <Compile Include="PerUserCacheKeyGeneratorTests.cs" />
     <Compile Include="DefaultCacheKeyGeneratorTests.cs" />
     <Compile Include="InlineInvalidateTests.cs">
@@ -92,6 +94,7 @@
     <Compile Include="InvalidateTests.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="CustomHeadersTests.cs" />
     <Compile Include="ServerSideTests.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -99,6 +102,7 @@
     <Compile Include="TestControllers\AutoInvalidateWithTypeController.cs" />
     <Compile Include="TestControllers\CacheKeyController.cs" />
     <Compile Include="TestControllers\CacheKeyGenerationController.cs" />
+    <Compile Include="TestControllers\CustomHeadersController.cs" />
     <Compile Include="TestControllers\IgnoreController.cs" />
     <Compile Include="TestControllers\InlineInvalidateController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -119,6 +123,9 @@
       <Project>{7a6f57f6-38e1-4287-812e-ad7d1025ba5e}</Project>
       <Name>WebApi2.OutputCache</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />


### PR DESCRIPTION
Based on https://github.com/filipw/Strathweb.CacheOutput/pull/126

But applied on top of latest version of dev branch with some changes:

- Respect content headers as well as response header.
- Do not serialize data inside the CacheOutputAttribute. Serialization may (or may not) be implemented in `IApiOutputCache` implementation, if needed. No need for client code to worry about it.
- Include unit tests.

Also, there is a tiny fix for `Get_until25012015_1700` test, as 2015 (and even 2018) has already passed by. 