### PR TITLE
Added support to set cache timeout in milliseconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+/.vs

--- a/src/WebApi.OutputCache.Core/Time/PreciseTime.cs
+++ b/src/WebApi.OutputCache.Core/Time/PreciseTime.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace WebApi.OutputCache.Core.Time
+{
+    public class PreciseTime : IModelQuery<DateTime, CacheTime>
+    {
+        private readonly TimeSpan _server;
+        private readonly TimeSpan _client;
+        private readonly TimeSpan? _shared;
+
+        public PreciseTime(TimeSpan server, TimeSpan client, TimeSpan? shared = null)
+        {
+            _server = server;
+            _client = client;
+            _shared = shared;
+        }
+
+        public CacheTime Execute(DateTime model)
+        {
+            return  new CacheTime
+            {
+                AbsoluteExpiration = model.Add(_server),
+                ClientTimeSpan = _client,
+                SharedTimeSpan = _shared
+            };
+        }
+    }
+}

--- a/src/WebApi.OutputCache.Core/Time/PreciseTime.cs
+++ b/src/WebApi.OutputCache.Core/Time/PreciseTime.cs
@@ -17,7 +17,7 @@ namespace WebApi.OutputCache.Core.Time
 
         public CacheTime Execute(DateTime model)
         {
-            return  new CacheTime
+            return new CacheTime
             {
                 AbsoluteExpiration = model.Add(_server),
                 ClientTimeSpan = _client,

--- a/src/WebApi.OutputCache.Core/WebApi.OutputCache.Core.csproj
+++ b/src/WebApi.OutputCache.Core/WebApi.OutputCache.Core.csproj
@@ -48,6 +48,7 @@
     <Compile Include="IModelQuery.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Time\CacheTime.cs" />
+    <Compile Include="Time\PreciseTime.cs" />
     <Compile Include="Time\ShortTime.cs" />
     <Compile Include="Time\SpecificTime.cs" />
     <Compile Include="Time\ThisDay.cs" />

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -72,19 +72,27 @@ namespace WebApi.OutputCache.V2
             set => _sharedTimeout = TimeSpan.FromSeconds(value);
         }
 
-
+        /// <summary>
+        /// Corresponds to CacheControl MaxAge HTTP header
+        /// </summary>
         public TimeSpan ClientTimeout
         {
             get => _clientTimeout;
             set => _clientTimeout = value;
         }
 
+        /// <summary>
+        /// How long response should be cached on the server side
+        /// </summary>
         public TimeSpan ServerTimeout
         {
             get => _serverTimeout;
             set => _serverTimeout = value;
         }
 
+        /// <summary>
+        /// Corresponds to CacheControl Shared MaxAge HTTP header
+        /// </summary>
         public TimeSpan? SharedTimeout
         {
             get => _sharedTimeout;

--- a/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
+++ b/src/WebApi.OutputCache.V2/CacheOutputAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -20,6 +21,8 @@ namespace WebApi.OutputCache.V2
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class CacheOutputAttribute : ActionFilterAttribute
     {
+        private static readonly IFormatProvider TimeoutFormatProvider = new CultureInfo("en-US");
+
         private const string CurrentRequestMediaType = "CacheOutput:CurrentRequestMediaType";
         protected static MediaTypeHeaderValue DefaultMediaType = new MediaTypeHeaderValue("application/json") {CharSet = Encoding.UTF8.HeaderName};
 
@@ -52,7 +55,7 @@ namespace WebApi.OutputCache.V2
         /// </summary>
         public int ClientTimeSpan
         {
-            get => (int)_clientTimeout.TotalSeconds;
+            get => (int) _clientTimeout.TotalSeconds;
             set => _clientTimeout = TimeSpan.FromSeconds(value);
         }
         
@@ -73,30 +76,30 @@ namespace WebApi.OutputCache.V2
         }
 
         /// <summary>
-        /// Corresponds to CacheControl MaxAge HTTP header
+        /// Corresponds to CacheControl MaxAge HTTP header (string in TimeSpan's en-US format)
         /// </summary>
-        public TimeSpan ClientTimeout
+        public string ClientTimeout
         {
-            get => _clientTimeout;
-            set => _clientTimeout = value;
+            get => _clientTimeout.ToString();
+            set => _clientTimeout = ParseTimeSpan(value);
         }
 
         /// <summary>
-        /// How long response should be cached on the server side
+        /// How long response should be cached on the server side (string in TimeSpan's en-US format)
         /// </summary>
-        public TimeSpan ServerTimeout
+        public string ServerTimeout
         {
-            get => _serverTimeout;
-            set => _serverTimeout = value;
+            get => _serverTimeout.ToString();
+            set => _serverTimeout = ParseTimeSpan(value);
         }
 
         /// <summary>
-        /// Corresponds to CacheControl Shared MaxAge HTTP header
+        /// Corresponds to CacheControl Shared MaxAge HTTP header (string in TimeSpan's en-US format)
         /// </summary>
-        public TimeSpan? SharedTimeout
+        public string SharedTimeout
         {
-            get => _sharedTimeout;
-            set => _sharedTimeout = value;
+            get => _sharedTimeout.ToString();
+            set => _sharedTimeout = string.IsNullOrEmpty(value) ?  null : (TimeSpan?) ParseTimeSpan(value);
         }
 
         /// <summary>
@@ -406,6 +409,11 @@ namespace WebApi.OutputCache.V2
                 var eTag = new EntityTagHeaderValue(@"""" + etag.Replace("\"", string.Empty) + @"""");
                 message.Headers.ETag = eTag;
             }
+        }
+
+        private static TimeSpan ParseTimeSpan(string input)
+        {
+            return TimeSpan.Parse(input, TimeoutFormatProvider);
         }
     }
 } 

--- a/test/WebApi.OutputCache.V2.Tests/ClientSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ClientSideTests.cs
@@ -37,6 +37,16 @@ namespace WebApi.OutputCache.V2.Tests
         }
 
         [Test]
+        public void maxageinmillis_mustrevalidate_false_headers_correct()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "GetStringTimeout_c500ms_s500ms").Result;
+
+            Assert.AreEqual(TimeSpan.FromMilliseconds(500), result.Headers.CacheControl.MaxAge);
+            Assert.IsFalse(result.Headers.CacheControl.MustRevalidate);
+        }
+
+        [Test]
         public void no_cachecontrol_when_clienttimeout_is_zero()
         {
             var client = new HttpClient(_server);

--- a/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
+++ b/test/WebApi.OutputCache.V2.Tests/ServerSideTests.cs
@@ -53,6 +53,18 @@ namespace WebApi.OutputCache.V2.Tests
             _cache.Verify(s => s.Add(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100:application/json; charset=utf-8"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x <= DateTime.Now.AddSeconds(100)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-get_c100_s100")), Times.Once());
         }
 
+
+        [Test]
+        public void set_cache_to_predefined_value_using_string_timeout()
+        {
+            var client = new HttpClient(_server);
+            var result = client.GetAsync(_url + "GetStringTimeout_c500ms_s500ms").Result;
+
+            _cache.Verify(s => s.Contains(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-getstringtimeout_c500ms_s500ms:application/json; charset=utf-8")), Times.Exactly(2));
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-getstringtimeout_c500ms_s500ms"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(1)), null), Times.Once());
+            _cache.Verify(s => s.Add(It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-getstringtimeout_c500ms_s500ms:application/json; charset=utf-8"), It.IsAny<object>(), It.Is<DateTimeOffset>(x => x < DateTime.Now.AddSeconds(1)), It.Is<string>(x => x == "webapi.outputcache.v2.tests.testcontrollers.samplecontroller-getstringtimeout_c500ms_s500ms")), Times.Once());
+        }
+
         [Test]
         public void set_cache_to_predefined_value_c100_s0()
         {

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
@@ -15,7 +15,7 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
             return "test";
         }
 
-        [CacheOutput(ClientTimeout = "0:00:00:00.500", ServerTimeout = "0:00:00:00.500")]
+        [CacheOutput(ClientTimeSpanMillis = 500, ServerTimeSpanMillis = 500)]
         public string GetStringTimeout_c500ms_s500ms()
         {
             return "test";

--- a/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
+++ b/test/WebApi.OutputCache.V2.Tests/TestControllers/SampleController.cs
@@ -15,6 +15,12 @@ namespace WebApi.OutputCache.V2.Tests.TestControllers
             return "test";
         }
 
+        [CacheOutput(ClientTimeout = "0:00:00:00.500", ServerTimeout = "0:00:00:00.500")]
+        public string GetStringTimeout_c500ms_s500ms()
+        {
+            return "test";
+        }
+
         [CacheOutput(ClientTimeSpan = 100, ServerTimeSpan = 0)]
         public string Get_c100_s0()
         {


### PR DESCRIPTION
As described in #263 it is quite limiting to be able to set up cache timeout only in seconds. So that I have added new `TimeSpan` properties to `CacheOutputAttribute` to set client, server and shared timeout. Also usage of `ShortTime` was replaced by new implementation of `IModelQuery<DateTime, CacheTime>` called `PreciseTime` that takes `TimeSpan` as constructor parameters.